### PR TITLE
Fix #65: Test and distribute before publishing

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -112,7 +112,7 @@ gulp.task("cover", function() {
 });
 
 gulp.task("test", function(cb) {
-  runSequence("istanbul:hook", "mocha", "cover", cb);
+  runSequence("build", "istanbul:hook", "mocha", "cover", cb);
 });
 
 //******************************************************************************

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,7 +111,7 @@ gulp.task("cover", function() {
       .pipe(coveralls());
 });
 
-gulp.task("test", function(cb) {
+gulp.task("build-and-test", function(cb) {
   runSequence("build", "istanbul:hook", "mocha", "cover", cb);
 });
 
@@ -163,8 +163,7 @@ gulp.task("dist", function(cb) {
 gulp.task("default", function (cb) {
   runSequence(
     "lint",
-    "build",
-    "test",
+    "build-and-test",
     "dist",
     cb);
 });

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "test": "gulp",
-    "prepublish": "gulp test && gulp dist"
+    "prepublish": "gulp build-and-test && gulp dist"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "gulp"
+    "test": "gulp",
+    "prepublish": "gulp test && gulp dist"
   },
   "repository": {
     "type": "git",

--- a/test/inject_annotation.test.ts
+++ b/test/inject_annotation.test.ts
@@ -5,60 +5,60 @@ import { Inject } from "../source/inversify";
 
 describe('Inject Annotation', () => {
    it('should generate metadata for annotated classes', () => {
-       
+
        interface IKatana {
            power : number;
            hit() : boolean;
        }
-       
+
        interface IShuriken {
            power : number;
            throw() : boolean;
        }
-       
+
        @Inject("IKatana", "IShuriken")
        class Warrior {
-           
+
            private _katana : IKatana;
            private _shuriken : IShuriken;
-           
+
            constructor(katana : IKatana, shuriken : IShuriken) {
                this._katana = katana;
                this._shuriken = shuriken;
            }
        }
-       
+
        class WarriorWithoutInjections {
-           
+
            private _katana : IKatana;
            private _shuriken : IShuriken;
-           
+
            constructor(katana : IKatana, shuriken : IShuriken) {
                this._katana = katana;
                this._shuriken = shuriken;
            }
        }
-       
+
        @Inject()
        class WarriorDecoratedWithoutInjections {
-           
+
            private _katana : IKatana;
            private _shuriken : IShuriken;
-           
+
            constructor(katana : IKatana, shuriken : IShuriken) {
                this._katana = katana;
                this._shuriken = shuriken;
            }
        }
-       
+
        var argumentTypes = (<any>Warrior).__INJECT;
        expect(argumentTypes.length).to.equal(2);
        expect(argumentTypes[0]).to.equal("IKatana");
        expect(argumentTypes[1]).to.equal("IShuriken");
-       
+
        var argumentTypes = (<any>WarriorWithoutInjections).__INJECT;
        expect(typeof argumentTypes).to.equal("undefined");
-       
+
        var argumentTypes = (<any>WarriorDecoratedWithoutInjections).__INJECT;
        expect(argumentTypes.length).to.equal(0);
    });


### PR DESCRIPTION
This automatically runs `gulp test`, followed by `gulp dist` before an `npm publish`, and will not publish if there is any issue with either of those two tasks.

I have tested this locally and it will not publish with failing tests.
