### PR TITLE
Fix #107: .npmignore test typing files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,4 +22,7 @@ wallaby.js
 # This will ignore:
 # inversify-test.js, inversify-test.ts
 # inversify-global-tests.js, inversify-global-tests.ts
-type_definitions/inversify/*-test*s
+type_definitions/inversify/*-test.js
+type_definitions/inversify/*-test.ts
+type_definitions/inversify/*-tests.js
+type_definitions/inversify/*-tests.ts

--- a/.npmignore
+++ b/.npmignore
@@ -18,3 +18,8 @@ wallaby.js
 .travis.yml
 .gitignore
 .vscode
+
+# This will ignore:
+# inversify-test.js, inversify-test.ts
+# inversify-global-tests.js, inversify-global-tests.ts
+type_definitions/inversify/*-test*s


### PR DESCRIPTION
## Description

Ignore the following patterns:

```
type_definitions/inversify/*-test.js
type_definitions/inversify/*-test.ts
type_definitions/inversify/*-tests.js
type_definitions/inversify/*-tests.ts
```

Which will ignore:
- `inversify-test.js`
- `inversify-test.ts`
- `inversify-global-tests.js`
- `inversify-global-tests.ts`
## Related Issue
#107
