### PR TITLE
Add build-es and build-lib gulp tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,8 @@ bundled
 typings
 .typingsrc
 dist
+lib
+es
 
 type_definitions/inversify/*.js
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "inversify",
   "version": "2.0.0-alpha.6",
   "description": "A lightweight IoC container written in TypeScript.",
-  "main": "dist/inversify.js",
+  "main": "lib/inversify.js",
+  "jsnext:main": "es/inversify.js",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Fix https://github.com/inversify/InversifyJS/issues/138

We now build a unbundled version of the app under the folder `lib`.
An ES2015 version understandable by recent bundlers like rollup and webpack2 is also available under the folder `es`.

I have tested this new setup with `webpack1` and `webpack2`. It works great! Webpack is finally stop yelling about:

```
WARNING in ./~/inversify/dist/inversify.js
Critical dependencies:
7:482-489 This seems to be a pre-built javascript file. Though this is possible, it's not recommended. Try to require the original source to get better results.
 @ ./~/inversify/dist/inversify.js 7:482-489
```

Like for the bundled version. I have included the banner (containing copyright, license and version) in each file of the folders `lib` and `es`.

Tell me if something is missing.
