### PR TITLE
Fix type definition location

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ npm install inversify@2.0.0-alpha.3 --save
 The InversifyJS type definitions are included in the npm package:
 
 ```ts
-/// <reference path="node_modules/inversify/type_definitions/inversify.d.ts" />
+/// <reference path="node_modules/inversify/type_definitions/inversify/inversify.d.ts" />
 ```
 > **Note**: InversifyJS requires a modern JavaScript engine with support for the Promise, Reflect (with metadata) and Proxy objects. If your environment don't support one of these you will need to import a shim or polypill. Check out the [Environment support and polyfills](https://github.com/inversify/InversifyJS/wiki/Environmemt-support-and-polyfills) page in the wiki to learn more.
 


### PR DESCRIPTION
Fixed the location path for type definition file from the example. It was incorrect. There are some inconsistencies between the different branches and formal documentation.
## Description

Not much to add, added a directory to the path.
## Related Issue
- None.
## Motivation and Context
- Beginners heads stop exploding.
## How Has This Been Tested?
- Mythical creatures came down from heavens and tried the compilation process out. Zero tests as the change was just to documentation as the directory it was pointing to was incorrect in the documentation.
## Types of changes
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
