### PR TITLE
Fixes #155

### DIFF
--- a/src/resolution/resolver.ts
+++ b/src/resolution/resolver.ts
@@ -55,8 +55,14 @@ class Resolver implements IResolver {
 
                     if (childRequests.length > 0) {
                         let injections = childRequests.map((childRequest) => {
-                            return this._resolve(childRequest);
+                            const res = this._resolve(childRequest);
+
+                            // if the target has a multi_inject tag and has one binding, return the resolved dep in an array
+                            return (childRequest.target && childRequest.target.isArray() && childRequest.bindings.length === 1) ?
+                                [res] :
+                                res;
                         });
+
                         result = this._createInstance(constr, injections);
                     } else {
                         result = new constr();

--- a/test/inversify.test.ts
+++ b/test/inversify.test.ts
@@ -768,6 +768,14 @@ describe("InversifyJS", () => {
         expect(ninja.katana.name).eql("Katana");
         expect(ninja.shuriken.name).eql("Shuriken");
 
+        // if only one value is bound to IWeapon
+        let kernel2 = new Kernel();
+        kernel2.bind<INinja>("INinja").to(Ninja);
+        kernel2.bind<IWeapon>("IWeapon").to(Katana);
+
+        let ninja2 = kernel2.get<INinja>("INinja");
+        expect(ninja2.katana.name).eql("Katana");
+
     });
 
     it("Should support the injection of multiple values when using classes as keys", () => {
@@ -811,6 +819,14 @@ describe("InversifyJS", () => {
         let ninja = kernel.get<Ninja>(Ninja);
         expect(ninja.katana.name).eql("Katana");
         expect(ninja.shuriken.name).eql("Shuriken");
+
+        // if only one value is bound to IWeapon
+        let kernel2 = new Kernel();
+        kernel2.bind<Ninja>(Ninja).to(Ninja);
+        kernel2.bind<Weapon>(Weapon).to(Katana);
+
+        let ninja2 = kernel2.get<Ninja>(Ninja);
+        expect(ninja2.katana.name).eql("Katana");
 
     });
 
@@ -858,6 +874,14 @@ describe("InversifyJS", () => {
         let ninja = kernel.get<INinja>(TYPES.INinja);
         expect(ninja.katana.name).eql("Katana");
         expect(ninja.shuriken.name).eql("Shuriken");
+
+        // if only one value is bound to IWeapon
+        let kernel2 = new Kernel();
+        kernel2.bind<INinja>(TYPES.INinja).to(Ninja);
+        kernel2.bind<IWeapon>(TYPES.IWeapon).to(Katana);
+
+        let ninja2 = kernel2.get<INinja>(TYPES.INinja);
+        expect(ninja2.katana.name).eql("Katana");
 
     });
 

--- a/test/resolution/resolver.test.ts
+++ b/test/resolution/resolver.test.ts
@@ -106,9 +106,9 @@ describe("Resolver", () => {
       let planner = new Planner();
       let context = planner.createContext(kernel);
 
-      /* 
+      /*
       *  Plan (request tree):
-      *  
+      *
       *  Ninja (target "null", no metadata)
       *   -- Katana (target "katama", no metadata)
       *       -- KatanaHandler (target "blade", no metadata)
@@ -210,9 +210,9 @@ describe("Resolver", () => {
       let planner = new Planner();
       let context = planner.createContext(kernel);
 
-      /* 
+      /*
       *  Plan (request tree):
-      *  
+      *
       *  Ninja (target "null", no metadata)
       *   -- Katana (target "katama", no metadata)
       *       -- KatanaHandler (target "blade", no metadata)
@@ -370,9 +370,9 @@ describe("Resolver", () => {
       let planner = new Planner();
       let context = planner.createContext(kernel);
 
-      /* 
+      /*
       *  Plan (request tree):
-      *  
+      *
       *  Ninja (target "null", no metadata)
       *   -- Katana (target "katama", no metadata)
       *   -- Shuriken (target "shuriken", no metadata)
@@ -1007,6 +1007,24 @@ describe("Resolver", () => {
       expect(ninja.katana instanceof Katana).eql(true);
       expect(ninja.shuriken instanceof Shuriken).eql(true);
 
+      // if only one value is bound to weaponId
+      let kernel2 = new Kernel();
+      kernel2.bind<INinja>(ninjaId).to(Ninja);
+      kernel2.bind<IWeapon>(weaponId).to(Katana);
+
+      let _kernel2: any = kernel2;
+      let ninjaBinding2 = _kernel2._bindingDictionary.get(ninjaId)[0];
+      let planner2 = new Planner();
+      let context2 = planner2.createContext(kernel2);
+      let plan2 = planner2.createPlan(context2, ninjaBinding2, null);
+      context2.addPlan(plan2);
+
+      let resolver2 = new Resolver();
+      let ninja2 = resolver2.resolve<INinja>(context2);
+
+      expect(ninja2 instanceof Ninja).eql(true);
+      expect(ninja2.katana instanceof Katana).eql(true);
+
   });
 
   it("Should be able to resolve plans with activation handlers", () => {
@@ -1042,7 +1060,7 @@ describe("Resolver", () => {
         let kernel = new Kernel();
         kernel.bind<INinja>(ninjaId).to(Ninja);
 
-        // This is a global for unit testing but remember 
+        // This is a global for unit testing but remember
         // that it is not a good idea to use globals
         let timeTracker: string[] = [];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Hi,

The resolver resolves correctly a request with a `mutliInject` tag with only one binding associated.
This PR fixes #155.

I have updated existing unit tests. Tell me if you prefer that I split them into new tests.
## Description

<!--- Describe your changes in detail -->
## Related Issue
#155
## Motivation and Context
#155
## How Has This Been Tested?

Unit tests for `resolver.ts` and `inversify.ts`.
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**EDIT:**
I have seen that I have trimmed some whitespace in `resolver.test.ts`. Tell me if that's ok.
