### PR TITLE
Fixes #168

### DIFF
--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -91,8 +91,8 @@ class Planner implements IPlanner {
 
             } else {
 
-                // one ore more than one matching bindings found 
-                // when more than 1 matching bindings found target is an array 
+                // one ore more than one matching bindings found
+                // when more than 1 matching bindings found target is an array
                 this._createChildRequest(parentRequest, target, activeBindings);
 
             }
@@ -188,7 +188,7 @@ class Planner implements IPlanner {
             let multiInject: any = targetMetadataMap[METADATA_KEY.MULTI_INJECT_TAG];
             let targetName: any = targetMetadataMap[METADATA_KEY.NAME_TAG];
 
-            // Take type to be injected from user-generated metadata 
+            // Take type to be injected from user-generated metadata
             // if not available use compiler-generated metadata
             targetType = (inject || multiInject) ? (inject || multiInject) : targetType;
 
@@ -207,7 +207,7 @@ class Planner implements IPlanner {
         }
 
         // Throw if a derived class does not implement its constructor explicitly
-        // We do this to prevent errors when a base class (parent) has dependencies 
+        // We do this to prevent errors when a base class (parent) has dependencies
         // and one of the derived classes (children) has no dependencies
         if (targets.length === 0 && this._baseClassHasDepencencies(func)) {
             throw new Error(`${ERROR_MSGS.MISSING_EXPLICIT_CONSTRUCTOR} ${constructorName}.`);
@@ -218,8 +218,11 @@ class Planner implements IPlanner {
 
     private _baseClassHasDepencencies(func: Function): boolean {
         let baseConstructor = Object.getPrototypeOf(func.prototype).constructor;
+
         if (baseConstructor !== Object) {
-            if (baseConstructor.length > 0) {
+            let targetsTypes = Reflect.getMetadata(METADATA_KEY.PARAM_TYPES, baseConstructor);
+
+            if (baseConstructor.length > 0 && targetsTypes) {
                 return true;
             } else {
                 return this._baseClassHasDepencencies(baseConstructor);

--- a/test/inversify.test.ts
+++ b/test/inversify.test.ts
@@ -1705,7 +1705,7 @@ describe("InversifyJS", () => {
 
     });
 
-    it("Should be able to inject into a supper constructor", () => {
+    it("Should be able to inject into a super constructor", () => {
 
         const SYMBOLS = {
             ISamurai: Symbol("ISamurai"),
@@ -1732,6 +1732,7 @@ describe("InversifyJS", () => {
 
         // Important: notice no anotations required in base class
         // However, it is recommended to annotate it as well
+        @injectable()
         class Samurai implements IWarrior {
 
             public weapon: IWeapon;
@@ -1770,6 +1771,41 @@ describe("InversifyJS", () => {
         let samuraiMaster2 = kernel.get<IWarrior>(SYMBOLS.ISamuraiMaster2);
         expect(samuraiMaster2.weapon.name).eql("katana");
         expect(typeof (<any>samuraiMaster2).isMaster).eql("boolean");
+
+    });
+
+    it("Should be able to inject a regular derived class", () => {
+
+        const SYMBOLS = {
+            ISamuraiMaster: Symbol("ISamuraiMaster"),
+        };
+
+        interface ISamurai {
+            rank: string;
+        }
+
+        class Samurai implements ISamurai {
+
+            public rank: string;
+
+            public constructor(rank: string) {
+                this.rank = rank;
+            }
+        }
+
+        @injectable()
+        class SamuraiMaster extends Samurai implements ISamurai {
+            constructor() {
+                super("Master");
+            }
+        }
+
+
+        const kernel = new Kernel();
+        kernel.bind<ISamurai>(SYMBOLS.ISamuraiMaster).to(SamuraiMaster);
+
+        let samurai = kernel.get<ISamurai>(SYMBOLS.ISamuraiMaster);
+        expect(samurai.rank).eql("Master");
 
     });
 


### PR DESCRIPTION
This fixes #168.

Inversify will raise the `MISSING_EXPLICIT_CONSTRUCTOR` error only if the base class is decorated by `@injectable()` and the user has forgotten to redeclare the constructor in the newly derived class (same condition introduced with https://github.com/inversify/InversifyJS/pull/158).
## Description

Since https://github.com/inversify/InversifyJS/pull/158, Inversify always raises an error when the user extends a class without redeclaring the constructor and injects this derived class 'somewhere' . This could lead to false positive.

For instance, the user could simply extends a class that has one parameter (that doesn't need to be injected).

**Case 1.**

``` ts
class Samurai implements ISamurai {

    public rank: string;

    public constructor(rank: string) {
        this.rank = rank;
    }
}

@injectable()
class SamuraiMaster extends Samurai implements ISamurai {
    constructor() {
        super("Master");
    }
}
```

``` ts
let samurai = kernel.get<ISamurai>("ISamuraiMaster");
expect(samurai.rank).eql("Master");
```

On the other side, the user could extend a class that has one parameter (that should be injected).

**Case 2.**

``` ts
class Samurai implements IWarrior {

    public weapon: IWeapon;

    public constructor(weapon: IWeapon) {
        this.weapon = weapon;
    }
}

@injectable()
class SamuraiMaster extends Samurai implements IWarrior {
    public isMaster: boolean;
    public constructor(@inject(SYMBOLS.IWeapon) weapon: IWeapon) {
        super(weapon);
        this.isMaster = true;
    }
}
```

This PR makes the error `MISSING_EXPLICIT_CONSTRUCTOR` raiser softer. It will be thrown only if the base class is also decorated with `@injectable()`. (In **case 2**, it means `Samurai` should be decorated with `@injectable()`). 
This will allows both case 1 & 2 to be valid.
## Related Issue

https://github.com/inversify/InversifyJS/issues/168
## Motivation and Context

https://github.com/inversify/InversifyJS/issues/168
## How Has This Been Tested?

Unit tests
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
