### PR TITLE
Removed global injection map

### DIFF
--- a/src/annotation/property_injectors.ts
+++ b/src/annotation/property_injectors.ts
@@ -1,47 +1,22 @@
 ///<reference path="../interfaces/interfaces.d.ts" />
 
+const INJECTION = Symbol();
+
 function _proxyGetter(
-    kernel: any,
-    serviceIdentifier: (string|Symbol|INewable<any>),
     proto: any,
     key: string,
-    resolve: (kernel: IKernel, serviceIdentifier: (string|Symbol|INewable<any>)) => any
+    resolve: () => any
 ) {
-
-    let globalInjectionMap: WeakMap<any, any> = kernel._injectedProperties;
-
-    let getter = function () {
-
-        let instanceInjections: Map<string, any> = globalInjectionMap.get(this);
-
-        if (instanceInjections == null) {
-            instanceInjections = new Map();
-            globalInjectionMap.set(this, instanceInjections);
+    function getter() {
+        if (!Reflect.hasMetadata(INJECTION, this, key)) {
+            Reflect.defineMetadata(INJECTION, resolve(), this, key);
         }
+        return Reflect.getMetadata(INJECTION, this, key);
+    }
 
-        if (!instanceInjections.has(key)) {
-            let val = resolve(kernel, serviceIdentifier);
-            instanceInjections.set(key, val);
-        }
-
-        return instanceInjections.get(key);
-
-    };
-
-    let  setter = function(newVal: any) {
-
-        let instanceInjections: Map<string, any> = globalInjectionMap.get(this);
-
-        if (instanceInjections == null) {
-            instanceInjections = new Map();
-            globalInjectionMap.set(this, instanceInjections);
-        }
-
-        instanceInjections.set(key, newVal);
-
-    };
-
-    delete proto[key];
+    function setter(newVal: any) {
+        Reflect.defineMetadata(INJECTION, newVal, this, key);
+    }
 
     Object.defineProperty(proto, key, {
         configurable: true,
@@ -49,18 +24,17 @@ function _proxyGetter(
         get: getter,
         set: setter
     });
-
 }
 
 function makePropertyInjectDecorator(kernel: IKernel) {
     return function(serviceIdentifier: (string|Symbol|INewable<any>)) {
         return function(proto: any, key: string): void {
 
-            let resolve = (krln: IKernel, srvId: (string|Symbol|INewable<any>)) => {
-                return krln.get(srvId);
+            let resolve = () => {
+                return kernel.get(serviceIdentifier);
             };
 
-            _proxyGetter(kernel, serviceIdentifier, proto, key, resolve);
+            _proxyGetter(proto, key, resolve);
 
         };
     };
@@ -70,11 +44,11 @@ function makePropertyInjectNamedDecorator(kernel: IKernel) {
     return function(serviceIdentifier: (string|Symbol|INewable<any>), named: string) {
         return function(proto: any, key: string): void {
 
-            let resolve = (krln: IKernel, srvId: (string|Symbol|INewable<any>)) => {
-                return krln.getNamed(srvId, named);
+            let resolve = () => {
+                return kernel.getNamed(serviceIdentifier, named);
             };
 
-            _proxyGetter(kernel, serviceIdentifier, proto, key, resolve);
+            _proxyGetter(proto, key, resolve);
 
         };
     };
@@ -84,11 +58,11 @@ function makePropertyInjectTaggedDecorator(kernel: IKernel) {
     return function(serviceIdentifier: (string|Symbol|INewable<any>), key: string, value: any) {
         return function(proto: any, propertyName: string): void {
 
-            let resolve = (krln: IKernel, srvId: (string|Symbol|INewable<any>)) => {
-                return krln.getTagged(srvId, key, value);
+            let resolve = () => {
+                return kernel.getTagged(serviceIdentifier, key, value);
             };
 
-            _proxyGetter(kernel, serviceIdentifier, proto, propertyName, resolve);
+            _proxyGetter(proto, propertyName , resolve);
 
         };
     };
@@ -98,11 +72,11 @@ function makePropertyMultiInjectDecorator(kernel: IKernel) {
     return function(serviceIdentifier: (string|Symbol|INewable<any>)) {
         return function(proto: any, key: string): void {
 
-            let resolve = (krln: IKernel, srvId: (string|Symbol|INewable<any>)) => {
-                return krln.getAll(srvId);
+            let resolve = () => {
+                return kernel.getAll(serviceIdentifier);
             };
 
-            _proxyGetter(kernel, serviceIdentifier, proto, key, resolve);
+            _proxyGetter(proto, key, resolve);
 
         };
     };

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -11,7 +11,7 @@
 // to declare a constructor that includes everything it
 // needs injected.
 
-// In order to resolve a depencency, the pico container needs
+// In order to resolve a dependency, the pico container needs
 // to be told which implementation type (classes) to associate
 // with each service type (interfaces).
 
@@ -33,7 +33,6 @@ class Kernel implements IKernel {
     private _resolver: IResolver;
     private _middleware: (context: IContext) => any;
     private _bindingDictionary: ILookup<IBinding<any>>;
-    private _injectedProperties: WeakMap<any, any>;
 
     // Initialize private properties
     public constructor() {
@@ -41,7 +40,6 @@ class Kernel implements IKernel {
         this._resolver = new Resolver();
         this._bindingDictionary = new Lookup<IBinding<any>>();
         this._middleware = null;
-        this._injectedProperties = new WeakMap();
     }
 
     public load(...modules: IKernelModule[]): void {


### PR DESCRIPTION
## Description

Removed global injection map like discussed.
Replaced logic by Reflect API calls
## How Has This Been Tested?

Tests are still green :)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
