### PR TITLE
Install typings on npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "test": "gulp",
-    "prepublish": "gulp build && gulp test"
+    "prepublish": "gulp build && gulp test",
+    "postinstall": "typings install"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -57,10 +57,11 @@
     "sinon": "^1.17.3",
     "tsify": "^0.16.0",
     "tslint": "^3.10.2",
+    "typedoc": ">=0.3.9",
     "typescript": "^1.8.10",
+    "typings": "^1.0.4",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.1.0",
-    "wallabify": "0.0.14",
-    "typedoc": ">=0.3.9"
+    "wallabify": "0.0.14"
   }
 }


### PR DESCRIPTION
## Description

Run `typings install` after a successful `npm install`.
## Related Issue

The initial `gulp build` command after an install fails as the typings have not been installed.
## Motivation and Context

Prevent contributors having to manually install typing files.
## How Has This Been Tested?

Tested on Node v5.6.0, Node v0.10.26, using npm v3.6.0
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
