### PR TITLE
Fix copy-past in TYPES table. #286

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ interface ThrowableWeapon {
 ```ts
 let TYPES = {
     Warrior: Symbol("Warrior"),
-    Warrior: Symbol("Weapon"),
-    Warrior: Symbol("ThrowableWeapon")
+    Weapon: Symbol("Weapon"),
+    ThrowableWeapon: Symbol("ThrowableWeapon")
 };
 
 export default TYPES;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

During reading readme file I've notices copy-paste in TYPES declaration.
## Description

<!--- Describe your changes in detail -->

Put correct key names.
## Related Issue

[Error in Readme file: copy-paste in TYPES declaration.](https://github.com/inversify/InversifyJS/issues/286)
