### PR TITLE
Fix #295 - Implement BindingInSyntax<T>.inTransientScope() 

### DIFF
--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -174,6 +174,7 @@ namespace interfaces {
 
     export interface BindingInSyntax<T> {
         inSingletonScope(): BindingWhenOnSyntax<T>;
+        inTransientScope(): BindingWhenOnSyntax<T>;
     }
 
     export interface BindingInWhenOnSyntax<T> extends BindingInSyntax<T>, BindingWhenOnSyntax<T> {}

--- a/src/syntax/binding_in_syntax.ts
+++ b/src/syntax/binding_in_syntax.ts
@@ -15,6 +15,11 @@ class BindingInSyntax<T> implements interfaces.BindingInSyntax<T> {
         return new BindingWhenOnSyntax<T>(this._binding);
     }
 
+    public inTransientScope(): interfaces.BindingWhenOnSyntax<T> {
+        this._binding.scope = BindingScope.Transient;
+        return new BindingWhenOnSyntax<T>(this._binding);
+    }
+
 }
 
 export default BindingInSyntax;

--- a/src/syntax/binding_in_when_on_syntax.ts
+++ b/src/syntax/binding_in_when_on_syntax.ts
@@ -21,6 +21,10 @@ class BindingInWhenOnSyntax<T> implements interfaces.BindingInSyntax<T>, interfa
         return this._bindingInSyntax.inSingletonScope();
     }
 
+    public inTransientScope(): interfaces.BindingWhenOnSyntax<T> {
+        return this._bindingInSyntax.inTransientScope();
+    }
+
     public when(constraint: (request: interfaces.Request) => boolean): interfaces.BindingOnSyntax<T> {
         return this._bindingWhenSyntax.when(constraint);
     }

--- a/test/syntax/binding_in_syntax.test.ts
+++ b/test/syntax/binding_in_syntax.test.ts
@@ -35,6 +35,10 @@ describe("BindingInSyntax", () => {
         bindingInSyntax.inSingletonScope();
         expect(binding.scope).eql(BindingScope.Singleton);
 
+        // set transient scope explicitly
+        bindingInSyntax.inTransientScope();
+        expect(binding.scope).eql(BindingScope.Transient);
+
     });
 
 });

--- a/test/syntax/binding_in_when_on_syntax.test.ts
+++ b/test/syntax/binding_in_when_on_syntax.test.ts
@@ -45,12 +45,15 @@ describe("BindingInWhenOnSyntax", () => {
 
         // stubs for BindingWhenSyntax methods
         let inSingletonScopeStub = sinon.stub(_bindingInWhenOnSyntax._bindingInSyntax, "inSingletonScope").returns(null);
+        let inTransientScopeStub = sinon.stub(_bindingInWhenOnSyntax._bindingInSyntax, "inTransientScope").returns(null);
 
         // invoke BindingWhenOnSyntax methods
         bindingInWhenOnSyntax.inSingletonScope();
+        bindingInWhenOnSyntax.inTransientScope();
 
         // assert invoked BindingWhenSyntax methods
         expect(inSingletonScopeStub.callCount).eql(1);
+        expect(inTransientScopeStub.callCount).eql(1);
 
     });
 


### PR DESCRIPTION
`inTransientScope` method was mentioned in the docs but was not implemented.

This PR implements the method 
## Description

Implemented `BindingInSyntax<T>.inTransientScope()` with same behaviour as `BindingInSyntax<T>.inSingletonScope()` just with **transient** binding scope.
## Related Issue

Fixes #295 
## Motivation and Context

`inTransientScope` method was mentioned in the docs but was not implemented.
## How Has This Been Tested?

Unit Test have been extended, basically coping the tests already implemented for `inSingletonScope` and changing the asserted value to **transient**
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to the type definitions.
- [x] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- Implement BindingInSyntax<T>.inTransientScope()
