### PR TITLE
add Kernel#parent setter. allow Planner to check for identifiers recu…

### DIFF
--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -36,6 +36,7 @@ class Kernel implements interfaces.Kernel {
     private _middleware: interfaces.PlanAndResolve<any>;
     private _bindingDictionary: interfaces.Lookup<Binding<any>>;
     private _snapshots: Array<KernelSnapshot>;
+    private _parentKernel: interfaces.Kernel;
 
     // Initialize private properties
     public constructor() {
@@ -164,6 +165,10 @@ class Kernel implements interfaces.Kernel {
             serviceIdentifier: serviceIdentifier,
             target: null
         });
+    }
+
+    public set parent (kernel: interfaces.Kernel) {
+        this._parentKernel = kernel;
     }
 
     private _get<T>(args: interfaces.PlanAndResolveArgs): T[] {

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -46,7 +46,13 @@ class Planner implements interfaces.Planner {
         let _bindingDictionary = _kernel._bindingDictionary;
         if (_bindingDictionary.hasKey(serviceIdentifier)) {
             bindings = _bindingDictionary.get(serviceIdentifier);
+
+        } else if (_kernel._parentKernel !== undefined) {
+            // recursively try to get bindings from parent kernel
+            bindings = this.getBindings<T>(_kernel._parentKernel, serviceIdentifier);
+
         }
+
         return bindings;
     }
 

--- a/test/kernel/kernel.test.ts
+++ b/test/kernel/kernel.test.ts
@@ -510,4 +510,44 @@ describe("Kernel", () => {
 
     });
 
+    it("Should be able to get services from parent kernel", () => {
+        let weaponIdentifier = "Weapon";
+
+        @injectable()
+        class Katana {}
+
+        let kernel = new Kernel();
+        kernel.bind(weaponIdentifier).to(Katana);
+
+        let childKernel = new Kernel();
+        childKernel.parent = kernel;
+
+        let secondChildKernel = new Kernel();
+        secondChildKernel.parent = childKernel;
+
+        expect(secondChildKernel.get(weaponIdentifier)).to.be.instanceOf(Katana);
+    });
+
+    it("Should prioritize requested kernel to resolve a service identifier", () => {
+        let weaponIdentifier = "Weapon";
+
+        @injectable()
+        class Katana {}
+
+        @injectable()
+        class DivineRapier {}
+
+        let kernel = new Kernel();
+        kernel.bind(weaponIdentifier).to(Katana);
+
+        let childKernel = new Kernel();
+        childKernel.parent = kernel;
+
+        let secondChildKernel = new Kernel();
+        secondChildKernel.parent = childKernel;
+        secondChildKernel.bind(weaponIdentifier).to(DivineRapier);
+
+        expect(secondChildKernel.get(weaponIdentifier)).to.be.instanceOf(DivineRapier);
+    });
+
 });


### PR DESCRIPTION
## Description

Implementation of #307. It was surprisingly simple to implement that I'm not sure I've covered everything. Please let me know if I missed something!
## Related Issue
#307
## Motivation and Context
#307
## How Has This Been Tested?
- Added test using [Kernel#get having two parents](https://github.com/endel/InversifyJS/commit/fabaf4998da85827583e5e93a6886a57ffe4c995#diff-fa0431f6b0c1d36b7988ebd765760097R513), and retrieving from root level.
- Added test having two parents and [retrieving from the requested level](https://github.com/endel/InversifyJS/commit/fabaf4998da85827583e5e93a6886a57ffe4c995#diff-fa0431f6b0c1d36b7988ebd765760097R531).
## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
