### PR TITLE
Run test with PhantomJS Karma launcher

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -137,7 +137,7 @@ gulp.task("build-es", function() {
 //******************************************************************************
 //* TESTS NODE
 //******************************************************************************
-var tstProject = tsc.createProject("tsconfig.json");
+var tstProject = tsc.createProject("tsconfig.json", { typescript: require("typescript") });
 
 gulp.task("build-src", function() {
     return gulp.src([
@@ -153,7 +153,7 @@ gulp.task("build-src", function() {
     .js.pipe(gulp.dest("src/"));
 });
 
-var tsTestProject = tsc.createProject("tsconfig.json");
+var tsTestProject = tsc.createProject("tsconfig.json", { typescript: require("typescript") });
 
 gulp.task("build-test", function() {
     return gulp.src([

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,8 @@
 var browsers = [
     "Firefox",
     "Chrome",
-    "IE"
+    "IE",
+    "PhantomJS"
 ];
 
 var plugins = [
@@ -11,7 +12,9 @@ var plugins = [
     "karma-sinon",
     "karma-firefox-launcher",
     "karma-chrome-launcher",
-    "karma-ie-launcher"
+    "karma-ie-launcher",
+    "karma-phantomjs-launcher",
+    "karma-es6-shim"
 ];
 
 module.exports = function (config) {
@@ -21,7 +24,7 @@ module.exports = function (config) {
   config.set({
     singleRun: true,
     basePath: "",
-    frameworks: ["mocha", "chai", "sinon"],
+    frameworks: ["mocha", "chai", "sinon", "es6-shim"],
     browsers: browsers,
     reporters: ["mocha"],
     plugins : plugins,

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^2.0.0",
     "karma-commonjs": "^1.0.0",
+    "karma-es6-shim": "^1.0.0",
     "karma-firefox-launcher": "^1.0.0",
     "karma-ie-launcher": "^1.0.0",
     "karma-mocha": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "karma-ie-launcher": "^1.0.0",
     "karma-mocha": "^1.1.1",
     "karma-mocha-reporter": "^2.0.5",
+    "karma-phantomjs-launcher": "^1.0.2",
     "karma-sinon": "^1.0.5",
     "mocha": "^3.0.1",
     "publish-please": "^2.1.4",


### PR DESCRIPTION
## Description

Run test with PhantomJS Karma launcher.
## Related Issue

N/A
## Motivation and Context

Reported by @endel on Gitter:

> I'm trying to test InversifyJS via Karma + PhantomJS and getting this error Missing required @injectable annotation in: xxx. Do you have some clue about this?
> Using the chrome-launcher it works perfectly... It happens only using phantomjs-launcher
## How Has This Been Tested?

Added phantomjs runner to karma config
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] My change requires a change to the type definitions.
- [ ] I have updated the type definitions accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
