### PR TITLE
add `parent` property on Kernel interface

### DIFF
--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -129,6 +129,7 @@ namespace interfaces {
 
     export interface Kernel {
         guid: string;
+        parent: Kernel;
         bind<T>(serviceIdentifier: ServiceIdentifier<T>): BindingToSyntax<T>;
         unbind(serviceIdentifier: ServiceIdentifier<any>): void;
         unbindAll(): void;


### PR DESCRIPTION
## Description

Added missing `parent` property on `Kernel` interface, which was implemented in #318
## Related Issue
#318, #307
## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
