### PR TITLE
minor fix for gulp-typescript v3 warnings

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,7 +45,7 @@ gulp.task("build-lib", function() {
     return gulp.src([
         "src/**/*.ts"
     ])
-    .pipe(tsc(tsLibProject))
+    .pipe(tsLibProject())
     .on("error", function (err) {
         process.exit(1);
     })
@@ -58,7 +58,7 @@ gulp.task("build-es", function() {
     return gulp.src([
         "src/**/*.ts"
     ])
-    .pipe(tsc(tsEsProject))
+    .pipe(tsEsProject())
     .on("error", function (err) {
         process.exit(1);
     })
@@ -67,7 +67,7 @@ gulp.task("build-es", function() {
 
 var tsDtsProject = tsc.createProject("tsconfig.json", {
     declaration: true,
-    noExternalResolve: false,
+    noResolve: false,
     typescript: require("typescript") 
 });
 
@@ -75,7 +75,7 @@ gulp.task("build-dts", function() {
     return gulp.src([
         "src/**/*.ts"
     ])
-    .pipe(tsc(tsDtsProject))
+    .pipe(tsDtsProject())
     .on("error", function (err) {
         process.exit(1);
     })
@@ -92,7 +92,7 @@ gulp.task("build-src", function() {
     return gulp.src([
         "src/**/*.ts"
     ])
-    .pipe(tsc(tstProject))
+    .pipe(tstProject())
     .on("error", function (err) {
         process.exit(1);
     })
@@ -105,7 +105,7 @@ gulp.task("build-test", function() {
     return gulp.src([
         "test/**/*.ts"
     ])
-    .pipe(tsc(tsTestProject))
+    .pipe(tsTestProject())
     .on("error", function (err) {
         process.exit(1);
     })


### PR DESCRIPTION
## Description

remove warnings from gulp-typescript 3.0
## Related Issue

This is somehow related to #378, but doesn't fix it completely
## Motivation and Context

0 warnings :smile: 
## Checklist:

Tests are still passing
