### PR TITLE
resolveInstance should create writable property

### DIFF
--- a/src/resolution/instantiation.ts
+++ b/src/resolution/instantiation.ts
@@ -19,7 +19,7 @@ function _injectProperties(
         let propertyName = "";
         propertyName = r.target.name.value();
         let injection = propertyInjections[index];
-        instance[propertyName] = injection;
+        Object.defineProperty(instance, propertyName, { value: injection, writable: true });
     });
 
     return instance;


### PR DESCRIPTION
Without this change, sometimes, I get following error:

TypeError: Cannot assign to read only property 'x' of #<Object>

More reading about this: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Read-only