### PR TITLE
isBound, isBoundNamed and isBoundTagged methods are checking ancestors

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -179,7 +179,11 @@ class Container implements interfaces.Container {
 
     // Allows to check if there are bindings available for serviceIdentifier
     public isBound(serviceIdentifier: interfaces.ServiceIdentifier<any>): boolean {
-        return this._bindingDictionary.hasKey(serviceIdentifier);
+        let bound = this._bindingDictionary.hasKey(serviceIdentifier);
+        if (!bound && this.parent) {
+            bound = this.parent.isBound(serviceIdentifier);
+        }
+        return bound;
     }
 
     public isBoundNamed(serviceIdentifier: interfaces.ServiceIdentifier<any>, named: string|number|symbol): boolean {

--- a/test/container/container.test.ts
+++ b/test/container/container.test.ts
@@ -365,6 +365,24 @@ describe("Container", () => {
         expect(secondChildContainer.get(weaponIdentifier)).to.be.instanceOf(Katana);
     });
 
+    it("Should be able to check if services are bound from parent container", () => {
+        let weaponIdentifier = "Weapon";
+
+        @injectable()
+        class Katana {}
+
+        let container = new Container();
+        container.bind(weaponIdentifier).to(Katana);
+
+        let childContainer = new Container();
+        childContainer.parent = container;
+
+        let secondChildContainer = new Container();
+        secondChildContainer.parent = childContainer;
+
+        expect(secondChildContainer.isBound(weaponIdentifier)).to.be.equal(true);
+    });
+
     it("Should prioritize requested container to resolve a service identifier", () => {
         let weaponIdentifier = "Weapon";
 

--- a/test/container/container.test.ts
+++ b/test/container/container.test.ts
@@ -601,6 +601,55 @@ describe("Container", () => {
 
     });
 
+    it("Should be able to check if a named binding is bound from parent container", () => {
+
+        const zero = "Zero";
+        const invalidDivisor = "InvalidDivisor";
+        const validDivisor = "ValidDivisor";
+        let container = new Container();
+        let childContainer = container.createChild();
+        let secondChildContainer = childContainer.createChild();
+
+        container.bind<number>(zero).toConstantValue(0).whenTargetNamed(invalidDivisor);
+        expect(secondChildContainer.isBoundNamed(zero, invalidDivisor)).to.eql(true);
+        expect(secondChildContainer.isBoundNamed(zero, validDivisor)).to.eql(false);
+
+        container.bind<number>(zero).toConstantValue(1).whenTargetNamed(validDivisor);
+        expect(secondChildContainer.isBoundNamed(zero, invalidDivisor)).to.eql(true);
+        expect(secondChildContainer.isBoundNamed(zero, validDivisor)).to.eql(true);
+
+    });
+
+    it("Should be able to get a tagged binding", () => {
+
+        const zero = "Zero";
+        const isValidDivisor = "IsValidDivisor";
+        let container = new Container();
+
+        container.bind<number>(zero).toConstantValue(0).whenTargetTagged(isValidDivisor, false);
+        expect(container.getTagged(zero, isValidDivisor, false)).to.eql(0);
+
+        container.bind<number>(zero).toConstantValue(1).whenTargetTagged(isValidDivisor, true);
+        expect(container.getTagged(zero, isValidDivisor, false)).to.eql(0);
+        expect(container.getTagged(zero, isValidDivisor, true)).to.eql(1);
+
+    });
+
+    it("Should be able to get a tagged binding from parent container", () => {
+
+        const zero = "Zero";
+        const isValidDivisor = "IsValidDivisor";
+        let container = new Container();
+        let childContainer = container.createChild();
+        let secondChildContainer = childContainer.createChild();
+
+        container.bind<number>(zero).toConstantValue(0).whenTargetTagged(isValidDivisor, false);
+        container.bind<number>(zero).toConstantValue(1).whenTargetTagged(isValidDivisor, true);
+        expect(secondChildContainer.getTagged(zero, isValidDivisor, false)).to.eql(0);
+        expect(secondChildContainer.getTagged(zero, isValidDivisor, true)).to.eql(1);
+
+    });
+
     it("Should be able check if a tagged binding is bound", () => {
 
         const zero = "Zero";
@@ -620,6 +669,24 @@ describe("Container", () => {
         container.bind<number>(zero).toConstantValue(1).whenTargetTagged(isValidDivisor, true);
         expect(container.isBoundTagged(zero, isValidDivisor, false)).to.eql(true);
         expect(container.isBoundTagged(zero, isValidDivisor, true)).to.eql(true);
+
+    });
+
+    it("Should be able to check if a tagged binding is bound from parent container", () => {
+
+        const zero = "Zero";
+        const isValidDivisor = "IsValidDivisor";
+        let container = new Container();
+        let childContainer = container.createChild();
+        let secondChildContainer = childContainer.createChild();
+
+        container.bind<number>(zero).toConstantValue(0).whenTargetTagged(isValidDivisor, false);
+        expect(secondChildContainer.isBoundTagged(zero, isValidDivisor, false)).to.eql(true);
+        expect(secondChildContainer.isBoundTagged(zero, isValidDivisor, true)).to.eql(false);
+
+        container.bind<number>(zero).toConstantValue(1).whenTargetTagged(isValidDivisor, true);
+        expect(secondChildContainer.isBoundTagged(zero, isValidDivisor, false)).to.eql(true);
+        expect(secondChildContainer.isBoundTagged(zero, isValidDivisor, true)).to.eql(true);
 
     });
 

--- a/wiki/container_api.md
+++ b/wiki/container_api.md
@@ -203,10 +203,6 @@ container.isBound(katanaSymbol)).eql(false);
 
 You can use the `isBoundNamed` method to check if there are registered bindings for a given service identifier with a given named constraint.
 
-> NOTE: We can only identify basic tagged bindings not complex constraints (e.g ancerstors).
-> Users can try-catch calls to container.get<T>("T") if they really need to do check if a
-> binding with a complex constraint is available.
-
 ```ts
 const zero = "Zero";
 const invalidDivisor = "InvalidDivisor";
@@ -231,10 +227,6 @@ expect(container.isBoundNamed(zero, validDivisor)).to.eql(true);
 ## container.isBoundTagged(serviceIdentifier: ServiceIdentifier<any>, key: string, value: any)
 
 You can use the `isBoundTagged` method to check if there are registered bindings for a given service identifier with a given tagged constraint.
-
-> NOTE: We can only identify basic tagged bindings not complex constraints (e.g ancerstors).
-> Users can try-catch calls to container.get<T>("T") if they really need to do check if a
-> binding with a complex constraint is available.
 
 ```ts
 const zero = "Zero";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The **isBound**, **isBoundNamed** and **isBoundTagged** methods are also checking if a parent container can also solves the request.

## Related Issue

[The isBound method from Container class is not checking parent on a child Container](https://github.com/inversify/InversifyJS/issues/611)

## Motivation and Context

The **Container** class allows the creation of a child container. When a **serviceIdentifier** is defined on the parent container, it's possible to **get** the service from the child container, but currently it's not possible to check if the child container can resolve the same **serviceIdentifier** through **isBound**, **isBoundNamed** and **isBoundTagged** methods.

## How Has This Been Tested?

New unit tests added to the **Container** test suit, ensuring that the **isBound**, **isBoundNamed** and **isBoundTagged** are solving complex constraints.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
