### PR TITLE
Fixes issue https://github.com/inversify/InversifyJS/issues/615

### DIFF
--- a/src/resolution/instantiation.ts
+++ b/src/resolution/instantiation.ts
@@ -34,7 +34,7 @@ function _createInstance(Func: interfaces.Newable<any>, injections: Object[]): a
 }
 
 function _postConstruct(constr: interfaces.Newable<any>, result: any): void {
-    if (Reflect.hasOwnMetadata(METADATA_KEY.POST_CONSTRUCT, constr)) {
+    if (Reflect.hasMetadata(METADATA_KEY.POST_CONSTRUCT, constr)) {
         let data: Metadata = Reflect.getMetadata(METADATA_KEY.POST_CONSTRUCT, constr);
         try {
             result[data.value]();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Replace `hasOwnMetadata` with `hasMetadata` when finding `POST_CONSTRUCT` metadata. This change fixes wrong behaviour described in https://github.com/inversify/InversifyJS/issues/615

<!--- Describe your changes in detail -->

## Motivation and Context

https://github.com/inversify/InversifyJS/issues/615

## How Has This Been Tested?

One new unit test was added. I also tested this on my own project

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
