### PR TITLE
Fix typo in "may or many not"

### DIFF
--- a/wiki/scope.md
+++ b/wiki/scope.md
@@ -41,7 +41,7 @@ The `inTransientScope` is used by default and we can select the scope of this ty
 
 When we invoke `container.get` for the first time and we are using `to`, `toSelf` or `toDynamicValue` the InversifyJS container will try to generate an object instance or value using a constructor or the dynamic value factory. If the scope has been set to `inSingletonScope` the value is cached. The second time we invoke `container.get` for the same resource ID, and if `inSingletonScope` has been selected, InversifyJS will try to get the value from the cache.
 
-Note that a class can have some dependencies and a dynamic value can access other types via the current context. These dependencies may or many not be a singleton independently of the selected scope of their parent object in their respective composition tree,
+Note that a class can have some dependencies and a dynamic value can access other types via the current context. These dependencies may or may not be a singleton independently of the selected scope of their parent object in their respective composition tree,
 
 ### Bindings that will inject a `function`
 In this group are included the following types of binding:


### PR DESCRIPTION
## Description

> "may or many not"
to 
> "may or may not"

## Related Issue

N/A

## Motivation and Context

N/A

## How Has This Been Tested?

N/A

## Types of changes

- [ X] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [N/A] My code follows the code style of this project.
- [N/A] My change requires a change to the documentation.
- [N/A] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [N/A] I have added tests to cover my changes.
- [N/A] All new and existing tests passed.
