### PR TITLE
Fixed @PostConstruct unit test so that it actually tests

### DIFF
--- a/test/resolution/resolver.test.ts
+++ b/test/resolution/resolver.test.ts
@@ -1143,7 +1143,7 @@ describe("Resolve", () => {
     });
 
     it("Should run the @PostConstruct method once in the singleton scope", () => {
-        let timesCalled = 1;
+        let timesCalled = 0;
         @injectable()
         class Katana {
             @postConstruct()
@@ -1175,7 +1175,8 @@ describe("Resolve", () => {
         container.bind<Ninja>(ninjaId).to(Ninja);
         container.bind<Samurai>(samuraiId).to(Samurai);
         container.bind<Katana>(katanaId).to(Katana).inSingletonScope();
-
+        container.get(ninjaId);
+        container.get(samuraiId);
         expect(timesCalled).to.be.equal(1);
 
   });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Should run the @PostConstruct method once in the singleton scope was testing that 1 equaled 1. The test never asked the container to create the instances.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Accurate testing
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Yes
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
