### PR TITLE
Fix #688, stacktrace loss

### DIFF
--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -198,7 +198,7 @@ function _createSubRequests(
         ) {
             circularDependencyToException(parentRequest.parentContext.plan.rootRequest);
         } else {
-            throw new Error(error.message);
+            throw error;
         }
     }
 }

--- a/src/syntax/binding_to_syntax.ts
+++ b/src/syntax/binding_to_syntax.ts
@@ -21,7 +21,7 @@ function factoryWrapper<T extends Function>(
                     ERROR_MSGS.CIRCULAR_DEPENDENCY_IN_FACTORY(factoryType, serviceIdentifier)
                 );
             } else {
-                throw new Error(error.message);
+                throw error;
             }
         }
     };


### PR DESCRIPTION
Fix stacktrace loss .

## Description

**replaced** occurrences of
``` typescript
 throw new Error(error.message);
```

**with**
``` typescript
 throw error;
```

in order to preserve stacktrace

## Related Issue

Fix #688 

## Motivations

Trying to inspect an error similar to #488

## How Has This Been Tested?

I found it too trivial to test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
