### PR TITLE
Support using functions returning service identifiers with @inject to avoid circular deps

### DIFF
--- a/src/annotation/inject.ts
+++ b/src/annotation/inject.ts
@@ -1,9 +1,14 @@
+import { UNDEFINED_INJECT_ANNOTATION } from "../constants/error_msgs";
 import * as METADATA_KEY from "../constants/metadata_keys";
 import { interfaces } from "../interfaces/interfaces";
 import { Metadata } from "../planning/metadata";
 import { tagParameter, tagProperty } from "./decorator_utils";
 
 function inject(serviceIdentifier: interfaces.ServiceIdentifier<any>) {
+  if (serviceIdentifier === undefined) {
+    throw new Error(UNDEFINED_INJECT_ANNOTATION);
+  }
+
   return function(target: any, targetKey: string, index?: number): void {
 
     const metadata = new Metadata(METADATA_KEY.INJECT_TAG, serviceIdentifier);

--- a/src/annotation/inject.ts
+++ b/src/annotation/inject.ts
@@ -4,13 +4,20 @@ import { interfaces } from "../interfaces/interfaces";
 import { Metadata } from "../planning/metadata";
 import { tagParameter, tagProperty } from "./decorator_utils";
 
-function inject(serviceIdentifier: interfaces.ServiceIdentifier<any>) {
-  if (serviceIdentifier === undefined) {
+export type ServiceIdentifierOrFunc = interfaces.ServiceIdentifier<any> | (() => interfaces.ServiceIdentifier<any>);
+
+function isSimpleFunction<T>(value: any): value is () => T {
+  return typeof value === "function" && value.length === 0;
+}
+
+function inject(serviceIdentifierOrFunc: ServiceIdentifierOrFunc) {
+  if (serviceIdentifierOrFunc === undefined) {
     throw new Error(UNDEFINED_INJECT_ANNOTATION);
   }
 
   return function(target: any, targetKey: string, index?: number): void {
-
+    const serviceIdentifier = isSimpleFunction<interfaces.ServiceIdentifier<any>>(serviceIdentifierOrFunc) ?
+      serviceIdentifierOrFunc() : serviceIdentifierOrFunc;
     const metadata = new Metadata(METADATA_KEY.INJECT_TAG, serviceIdentifier);
 
     if (typeof index === "number") {

--- a/src/constants/error_msgs.ts
+++ b/src/constants/error_msgs.ts
@@ -7,8 +7,10 @@ export const CANNOT_UNBIND = "Could not unbind serviceIdentifier:";
 export const NOT_REGISTERED = "No matching bindings found for serviceIdentifier:";
 export const MISSING_INJECTABLE_ANNOTATION = "Missing required @injectable annotation in:";
 export const MISSING_INJECT_ANNOTATION = "Missing required @inject or @multiInject annotation in:";
-export const UNDEFINED_INJECT_ANNOTATION = "@inject called with undefined this could mean that you " +
-    "have circular dependency problem in your code.";
+export const UNDEFINED_INJECT_ANNOTATION = (name: string) =>
+            `@inject called with undefined this could mean that the class ${name} has ` +
+            "a circular dependency problem. You can use a LazyServiceIdentifer to  " +
+            "overcome this limitation.";
 export const CIRCULAR_DEPENDENCY = "Circular dependency found:";
 export const NOT_IMPLEMENTED = "Sorry, this feature is not fully implemented yet.";
 export const INVALID_BINDING_TYPE = "Invalid binding type:";

--- a/src/constants/error_msgs.ts
+++ b/src/constants/error_msgs.ts
@@ -7,6 +7,8 @@ export const CANNOT_UNBIND = "Could not unbind serviceIdentifier:";
 export const NOT_REGISTERED = "No matching bindings found for serviceIdentifier:";
 export const MISSING_INJECTABLE_ANNOTATION = "Missing required @injectable annotation in:";
 export const MISSING_INJECT_ANNOTATION = "Missing required @inject or @multiInject annotation in:";
+export const UNDEFINED_INJECT_ANNOTATION = "@inject called with undefined this could mean that you " +
+    "have circular dependency problem in your code.";
 export const CIRCULAR_DEPENDENCY = "Circular dependency found:";
 export const NOT_IMPLEMENTED = "Sorry, this feature is not fully implemented yet.";
 export const INVALID_BINDING_TYPE = "Invalid binding type:";

--- a/src/inversify.ts
+++ b/src/inversify.ts
@@ -6,7 +6,7 @@ export { ContainerModule } from "./container/container_module";
 export { injectable } from "./annotation/injectable";
 export { tagged } from "./annotation/tagged";
 export { named } from "./annotation/named";
-export { inject } from "./annotation/inject";
+export { inject, LazyServiceIdentifer } from "./annotation/inject";
 export { optional } from "./annotation/optional";
 export { unmanaged } from "./annotation/unmanaged";
 export { multiInject } from "./annotation/multi_inject";

--- a/src/planning/reflection_utils.ts
+++ b/src/planning/reflection_utils.ts
@@ -1,3 +1,4 @@
+import { LazyServiceIdentifer } from "../annotation/inject";
 import * as ERROR_MSGS from "../constants/error_msgs";
 import { TargetTypeEnum } from "../constants/literal_types";
 import * as METADATA_KEY from "../constants/metadata_keys";
@@ -83,6 +84,11 @@ function getConstructorArgsAsTarget(
     let serviceIdentifier = serviceIdentifiers[index];
     const injectIdentifier  = (metadata.inject || metadata.multiInject);
     serviceIdentifier = (injectIdentifier) ? (injectIdentifier) : serviceIdentifier;
+
+    // we unwrap LazyServiceIdentifer wrappers to allow circular dependencies on symbols
+    if (serviceIdentifier instanceof LazyServiceIdentifer) {
+        serviceIdentifier = serviceIdentifier.unwrap();
+    }
 
     // Types Object and Function are too ambiguous to be resolved
     // user needs to generate metadata manually for those

--- a/test/annotation/inject.test.ts
+++ b/test/annotation/inject.test.ts
@@ -3,7 +3,7 @@ declare function __param(paramIndex: number, decorator: ParameterDecorator): Cla
 
 import { expect } from "chai";
 import { decorate } from "../../src/annotation/decorator_utils";
-import { inject } from "../../src/annotation/inject";
+import { inject, LazyServiceIdentifer } from "../../src/annotation/inject";
 import * as ERROR_MSGS from "../../src/constants/error_msgs";
 import * as METADATA_KEY from "../../src/constants/metadata_keys";
 import { interfaces } from "../../src/interfaces/interfaces";
@@ -15,6 +15,8 @@ class Katana implements Katana {}
 class Shuriken implements Shuriken {}
 class Sword implements Sword {}
 
+const lazySwordId = new LazyServiceIdentifer(() => "Sword");
+
 class DecoratedWarrior {
 
     private _primaryWeapon: Katana;
@@ -24,7 +26,7 @@ class DecoratedWarrior {
     public constructor(
       @inject("Katana") primary: Katana,
       @inject("Shuriken") secondary: Shuriken,
-      @inject(() => "Sword") tertiary: Shuriken
+      @inject(lazySwordId) tertiary: Shuriken
     ) {
         this._primaryWeapon = primary;
         this._secondaryWeapon = secondary;
@@ -92,7 +94,7 @@ describe("@inject", () => {
     expect(paramsMetadata["2"]).to.be.instanceof(Array);
     const m3: interfaces.Metadata = paramsMetadata["2"][0];
     expect(m3.key).to.be.eql(METADATA_KEY.INJECT_TAG);
-    expect(m3.value).to.be.eql("Sword");
+    expect(m3.value).to.be.eql(lazySwordId);
     expect(paramsMetadata["2"][1]).to.eq(undefined);
 
     // no more metadata should be available
@@ -131,7 +133,7 @@ describe("@inject", () => {
       __decorate([ __param(0, inject(undefined as any)) ], InvalidDecoratorUsageWarrior);
     };
 
-    const msg = `${ERROR_MSGS.UNDEFINED_INJECT_ANNOTATION}`;
+    const msg = `${ERROR_MSGS.UNDEFINED_INJECT_ANNOTATION("InvalidDecoratorUsageWarrior")}`;
     expect(useDecoratorWithUndefined).to.throw(msg);
 
   });

--- a/test/annotation/inject.test.ts
+++ b/test/annotation/inject.test.ts
@@ -112,6 +112,18 @@ describe("@inject", () => {
 
   });
 
+  it("Should throw when applied with undefined", () => {
+
+    // this can happen when there is circular dependency between symbols
+    const useDecoratorWithUndefined = function() {
+      __decorate([ __param(0, inject(undefined as any)) ], InvalidDecoratorUsageWarrior);
+    };
+
+    const msg = `${ERROR_MSGS.UNDEFINED_INJECT_ANNOTATION}`;
+    expect(useDecoratorWithUndefined).to.throw(msg);
+
+  });
+
   it("Should be usable in VanillaJS applications", () => {
 
     interface Shurien {}

--- a/test/annotation/inject.test.ts
+++ b/test/annotation/inject.test.ts
@@ -10,27 +10,32 @@ import { interfaces } from "../../src/interfaces/interfaces";
 
 interface Katana {}
 interface Shuriken {}
+interface Sword {}
 class Katana implements Katana {}
 class Shuriken implements Shuriken {}
+class Sword implements Sword {}
 
 class DecoratedWarrior {
 
     private _primaryWeapon: Katana;
     private _secondaryWeapon: Shuriken;
+    private _tertiaryWeapon: Sword;
 
     public constructor(
       @inject("Katana") primary: Katana,
-      @inject("Shuriken") secondary: Shuriken
+      @inject("Shuriken") secondary: Shuriken,
+      @inject(() => "Sword") tertiary: Shuriken
     ) {
-
         this._primaryWeapon = primary;
         this._secondaryWeapon = secondary;
+        this._tertiaryWeapon = tertiary;
     }
 
     public debug() {
       return {
         primaryWeapon: this._primaryWeapon,
-        secondaryWeapon: this._secondaryWeapon
+        secondaryWeapon: this._secondaryWeapon,
+        tertiaryWeapon: this._tertiaryWeapon
       };
     }
 
@@ -83,8 +88,15 @@ describe("@inject", () => {
     expect(m2.value).to.be.eql("Shuriken");
     expect(paramsMetadata["1"][1]).to.eq(undefined);
 
+    // assert metadata for second argument
+    expect(paramsMetadata["2"]).to.be.instanceof(Array);
+    const m3: interfaces.Metadata = paramsMetadata["2"][0];
+    expect(m3.key).to.be.eql(METADATA_KEY.INJECT_TAG);
+    expect(m3.value).to.be.eql("Sword");
+    expect(paramsMetadata["2"][1]).to.eq(undefined);
+
     // no more metadata should be available
-    expect(paramsMetadata["2"]).to.eq(undefined);
+    expect(paramsMetadata["3"]).to.eq(undefined);
 
   });
 


### PR DESCRIPTION
## Description
First commit introduces guard check to prohibit injecting `undefined` values as service identifiers. This could happen when circular dependency between symbols is detected.

Second commit adds a possibility to inject parameterless functions returning service identifiers. Implementation is not as nice as I imagined because `ServiceIdentifier` can itself be a `newable` or `abstract` — i don't really understand this usecase but this is in typings. @remojansen could you point me to some docs? 

Documenting this change is missing. I wanted to discuss this solution first. 

## Related Issue
https://github.com/inversify/InversifyJS/issues/772

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I added new test cases. 

Previously it was possible to pass `newable` or `abstract`. Now if parameteless function is detected we invoke it immediately. This is a breaking change. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
