### PR TITLE
Added new feature to disable base class checking

### DIFF
--- a/src/constants/error_msgs.ts
+++ b/src/constants/error_msgs.ts
@@ -24,8 +24,8 @@ export const INVALID_TO_SELF_VALUE = "The toSelf function can only be applied wh
 export const INVALID_DECORATOR_OPERATION = "The @inject @multiInject @tagged and @named decorators " +
     "must be applied to the parameters of a class constructor or a class property.";
 
-export const ARGUMENTS_LENGTH_MISMATCH_1 = "The number of constructor arguments in the derived class ";
-export const ARGUMENTS_LENGTH_MISMATCH_2 = " must be >= than the number of constructor arguments of its base class.";
+export const ARGUMENTS_LENGTH_MISMATCH = (...values: any[]) => "The number of constructor arguments in the derived class " +
+    `${values[0]} must be >= than the number of constructor arguments of its base class.`;
 
 export const CONTAINER_OPTIONS_MUST_BE_AN_OBJECT = "Invalid Container constructor argument. Container options " +
     "must be an object.";
@@ -34,6 +34,9 @@ export const CONTAINER_OPTIONS_INVALID_DEFAULT_SCOPE = "Invalid Container option
     "be a string ('singleton' or 'transient').";
 
 export const CONTAINER_OPTIONS_INVALID_AUTO_BIND_INJECTABLE = "Invalid Container option. Auto bind injectable must " +
+    "be a boolean";
+
+export const CONTAINER_OPTIONS_INVALID_SKIP_BASE_CHECK = "Invalid Container option. Skip base check must " +
     "be a boolean";
 
 export const MULTIPLE_POST_CONSTRUCT_METHODS = "Cannot apply @postConstruct decorator multiple times in the same class";

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -50,38 +50,42 @@ class Container implements interfaces.Container {
     }
 
     public constructor(containerOptions?: interfaces.ContainerOptions) {
-
-        if (containerOptions !== undefined) {
-
-            if (typeof containerOptions !== "object") {
-                throw new Error(`${ERROR_MSGS.CONTAINER_OPTIONS_MUST_BE_AN_OBJECT}`);
-            } else {
-                if (containerOptions.defaultScope !== undefined &&
-                    containerOptions.defaultScope !== BindingScopeEnum.Singleton &&
-                    containerOptions.defaultScope !== BindingScopeEnum.Transient &&
-                    containerOptions.defaultScope !== BindingScopeEnum.Request
-                ) {
-                    throw new Error(`${ERROR_MSGS.CONTAINER_OPTIONS_INVALID_DEFAULT_SCOPE}`);
-                }
-
-                if (containerOptions.autoBindInjectable !== undefined &&
-                    typeof containerOptions.autoBindInjectable !== "boolean"
-                ) {
-                    throw new Error(`${ERROR_MSGS.CONTAINER_OPTIONS_INVALID_AUTO_BIND_INJECTABLE}`);
-                }
-            }
-
-            this.options = {
-                autoBindInjectable: containerOptions.autoBindInjectable,
-                defaultScope: containerOptions.defaultScope
-            };
-
-        } else {
-            this.options = {
-                autoBindInjectable: false,
-                defaultScope: BindingScopeEnum.Transient
-            };
+        const options = containerOptions || {};
+        if (typeof options !== "object") {
+            throw new Error(`${ERROR_MSGS.CONTAINER_OPTIONS_MUST_BE_AN_OBJECT}`);
         }
+
+        if (options.defaultScope === undefined) {
+            options.defaultScope = BindingScopeEnum.Transient;
+        } else if (
+            options.defaultScope !== BindingScopeEnum.Singleton &&
+            options.defaultScope !== BindingScopeEnum.Transient &&
+            options.defaultScope !== BindingScopeEnum.Request
+        ) {
+            throw new Error(`${ERROR_MSGS.CONTAINER_OPTIONS_INVALID_DEFAULT_SCOPE}`);
+        }
+
+        if (options.autoBindInjectable === undefined) {
+            options.autoBindInjectable = false;
+        } else if (
+            typeof options.autoBindInjectable !== "boolean"
+        ) {
+            throw new Error(`${ERROR_MSGS.CONTAINER_OPTIONS_INVALID_AUTO_BIND_INJECTABLE}`);
+        }
+
+        if (options.skipBaseClassChecks === undefined) {
+            options.skipBaseClassChecks = false;
+        } else if (
+            typeof options.skipBaseClassChecks !== "boolean"
+        ) {
+            throw new Error(`${ERROR_MSGS.CONTAINER_OPTIONS_INVALID_SKIP_BASE_CHECK}`);
+        }
+
+        this.options = {
+            autoBindInjectable: options.autoBindInjectable,
+            defaultScope: options.defaultScope,
+            skipBaseClassChecks: options.skipBaseClassChecks
+        };
 
         this.guid = guid();
         this._bindingDictionary = new Lookup<interfaces.Binding<any>>();

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -158,6 +158,7 @@ namespace interfaces {
     export interface ContainerOptions {
         autoBindInjectable?: boolean;
         defaultScope?: BindingScope;
+        skipBaseClassChecks?: boolean;
     }
 
     export interface Container {

--- a/src/planning/reflection_utils.ts
+++ b/src/planning/reflection_utils.ts
@@ -53,17 +53,6 @@ function getTargets(
         ...propertyTargets
     ];
 
-    // Throw if a derived class does not implement its constructor explicitly
-    // We do this to prevent errors when a base class (parent) has dependencies
-    // and one of the derived classes (children) has no dependencies
-    const baseClassDependencyCount = getBaseClassDependencyCount(metadataReader, func);
-
-    if (targets.length < baseClassDependencyCount) {
-        const error = ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH_1 +
-                    constructorName + ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH_2;
-        throw new Error(error);
-    }
-
     return targets;
 
 }
@@ -233,4 +222,4 @@ function formatTargetMetadata(targetMetadata: any[]) {
 
 }
 
-export { getDependencies };
+export { getDependencies, getBaseClassDependencyCount, getFunctionName };

--- a/test/bugs/bugs.test.ts
+++ b/test/bugs/bugs.test.ts
@@ -43,7 +43,7 @@ describe("Bugs", () => {
             container.get<SamuraiMaster>(SamuraiMaster);
         };
 
-        const error = ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH_1 + "SamuraiMaster" + ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH_2;
+        const error = ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH("SamuraiMaster");
         expect(shouldThrow).to.throw(error);
 
     });

--- a/test/inversify.test.ts
+++ b/test/inversify.test.ts
@@ -1993,7 +1993,7 @@ describe("InversifyJS", () => {
         container.bind<Warrior>(SYMBOLS.SamuraiMaster2).to(SamuraiMaster2);
 
         const errorFunction = () => { container.get<Warrior>(SYMBOLS.SamuraiMaster); };
-        const error = ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH_1 + "SamuraiMaster" + ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH_2;
+        const error = ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH("SamuraiMaster");
         expect(errorFunction).to.throw(error);
 
         const samuraiMaster2 = container.get<SamuraiMaster2>(SYMBOLS.SamuraiMaster2);
@@ -2027,7 +2027,7 @@ describe("InversifyJS", () => {
 
         container.bind<Base1>(Base1Id).to(Derived1);
         const tryGet = () => { container.get(Base1Id); };
-        const error = ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH_1 + "Derived1" + ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH_2;
+        const error = ERROR_MSGS.ARGUMENTS_LENGTH_MISMATCH("Derived1");
         expect(tryGet).to.throw(error);
 
         // CASE 2: Use @unmanaged to overcome issue

--- a/test/planning/planner.test.ts
+++ b/test/planning/planner.test.ts
@@ -482,6 +482,17 @@ describe("Planner", () => {
 
     });
 
+    it("Should ignore checking base classes for @injectable when skipBaseClassChecks is set on the container", () => {
+        class Test { }
+
+        @injectable()
+        class Test2 extends Test { }
+
+        const container = new Container({skipBaseClassChecks: true});
+        container.bind(Test2).toSelf();
+        container.get(Test2);
+    });
+
     it("Should throw when an class has a missing @inject annotation", () => {
 
         interface Sword { }

--- a/wiki/container_api.md
+++ b/wiki/container_api.md
@@ -39,6 +39,16 @@ container.bind(Ninja).to(Samurai);
 container.get(Ninja);              // returns a Samurai
 ```
 
+### skipBaseClassChecks
+
+You can use this to skip checking base classes for the @injectable property, which is
+especially useful if any of your @injectable classes extend classes that you don't control
+(third party classes). By default, this value is `false`.
+
+```ts
+let container = new Container({ skipBaseClassChecks: true });
+```
+
 ## Container.merge(a: Container, b: Container)
 
 Merges two containers into one:

--- a/wiki/inheritance.md
+++ b/wiki/inheritance.md
@@ -208,6 +208,34 @@ container.bind<string>(TYPES.Rank)
 
 ```
 
+### WORKAROUND E) Skip Base class `@injectable` checks
+
+Setting the `skipBaseClassChecks` option to `true` for the container will disable all checking of base classes. This means it will be completely up to the developer to ensure that the `super()` constructor is called with the correct arguments and at the correct time.
+
+```ts
+// Not injectable
+class UnmanagedBase {
+    public constructor(
+        public unmanagedDependency: string
+    ) {
+    }
+}
+
+@injectable()
+class InjectableDerived extends UnmanagedBase  {
+    public constructor(
+        // Any arguments defined here will be injected like normal
+    ) {
+        super("Don't forget me...");
+    }
+}
+
+const container = new Container({skipBaseClassChecks: true});
+container.bind(InjectableDerived).toSelf();
+```
+
+This will work, and you'll be able to use your `InjectableDerived` class just like normal, including injecting dependencies from elsewhere in the container through the constructor. The one caveat is that you must make sure your `UnmanagedBase` receives the correct arguments.
+
 ## What can I do when my base class is provided by a third party module?
 In some cases, you may get errors about missing annotations in classes 
 provided by a third party module like:


### PR DESCRIPTION
## Description

Added an option to the container to skip checking base classes for @injectable classes.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

These issues are all related to this particular problem, but are most likely using workarounds:

https://github.com/inversify/InversifyJS/issues/528
https://github.com/inversify/InversifyJS/issues/297
https://github.com/inversify/InversifyJS/issues/729

This issue is still open, and quite accurately explains why this feature is desirable:

https://github.com/inversify/InversifyJS/issues/522

## Motivation and Context

This change is a simple quality of life fix for those who are creating injectable
classes by extending classes provided by third parties. The only reason this check is
currently in place is to assist developers who may forget to call `super()` with the correct
arguments to instantiate the parent class. For those developers who wish to forgo those built
in checks, this options should save them the trouble of decorating all parent
classes with @injectable/@unmanaged (since this quite tedious, and may cause unforseen problems
with 3rd party libraries).

## How Has This Been Tested?

I have added a simple test in the planner test file, and have run the rest of the test suite.
It behaves as expected without the option (throws an error on base classes that are not @injectable), and behaves as expected with the option.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
