### PR TITLE
Added request caching for Singletons

### DIFF
--- a/src/bindings/binding.ts
+++ b/src/bindings/binding.ts
@@ -42,6 +42,9 @@ class Binding<T> implements interfaces.Binding<T> {
     // On activation handler (invoked just before an instance is added to cache and injected)
     public onActivation: ((context: interfaces.Context, injectable: T) => T) | null;
 
+    // The request to resolve the binding.
+    public request: interfaces.Request | null;
+
     public constructor(serviceIdentifier: interfaces.ServiceIdentifier<T>, scope: interfaces.BindingScope) {
         this.id = id();
         this.activated = false;
@@ -55,6 +58,7 @@ class Binding<T> implements interfaces.Binding<T> {
         this.provider = null;
         this.onActivation = null;
         this.dynamicValue = null;
+        this.request = null;
     }
 
     public clone(): interfaces.Binding<T> {
@@ -69,6 +73,7 @@ class Binding<T> implements interfaces.Binding<T> {
         clone.constraint = this.constraint;
         clone.onActivation = this.onActivation;
         clone.cache = this.cache;
+        clone.request = this.request;
         return clone;
     }
 

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -56,6 +56,7 @@ namespace interfaces {
         provider: ProviderCreator<any> | null;
         onActivation: ((context: interfaces.Context, injectable: T) => T) | null;
         cache: T | null;
+        request: interfaces.Request | null;
     }
 
     export type Factory<T> = (...args: any[]) => (((...args: any[]) => T) | T);

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -1,6 +1,6 @@
 import { BindingCount } from "../bindings/binding_count";
 import * as ERROR_MSGS from "../constants/error_msgs";
-import { BindingTypeEnum, TargetTypeEnum } from "../constants/literal_types";
+import { BindingScopeEnum, BindingTypeEnum, TargetTypeEnum } from "../constants/literal_types";
 import * as METADATA_KEY from "../constants/metadata_keys";
 import { interfaces } from "../interfaces/interfaces";
 import { isStackOverflowExeption } from "../utils/exceptions";
@@ -174,8 +174,15 @@ function _createSubRequests(
             if (binding.cache) {
                 return;
             }
+
+            if (binding.scope === BindingScopeEnum.Singleton && binding.request) {
+                return;
+            }
+
             subChildRequest = childRequest;
         }
+
+        binding.request = subChildRequest;
 
         if (binding.type === BindingTypeEnum.Instance && binding.implementationType !== null) {
 


### PR DESCRIPTION
## Description
For singleton bindings, ensuring that multiple Request objects are not created as there will be only one Instance finally.

## Related Issue
https://github.com/inversify/InversifyJS/issues/1115

## Motivation and Context
We have a complex application with a huge dependency graph. On startup, when all controllers are initialized at once using inversify-express-utils (container.getAll for controllers) we noticed that the startup takes upward of 5 minutes, with more than 6 GB of memory taken for the plan graph. Most of our bindings are Singleton. With this change, startup reduces to a few seconds, and about 600 MB memory

## How Has This Been Tested?
Tested my applications with the new changes, dependencies are being injected correctly. 
Also added/modified test cases as required

## Types of changes
- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the changelog.
