### PR TITLE
Pull request for Global activation hooks #471

### DIFF
--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -54,7 +54,7 @@ namespace interfaces {
         implementationType: Newable<T> | null;
         factory: FactoryCreator<any> | null;
         provider: ProviderCreator<any> | null;
-        onActivation: ((context: interfaces.Context, injectable: T) => T) | null;
+        onActivation: OnActivationHandler<T> | null;
         cache: T | null;
     }
 
@@ -185,8 +185,20 @@ namespace interfaces {
         snapshot(): void;
         restore(): void;
         createChild(): Container;
+        onActivation<T>(handler: OnActivationHandler<T>, options?: interfaces.GlobalOnActivationOptions<T>): void;
     }
-
+    export type OnActivationHandler<T> = (context: interfaces.Context, injectable: T) => T;
+    export interface GlobalOnActivationOptions<T> {
+        removeExisting?: boolean;
+        filter?: (
+            serviceIdentifier: interfaces.ServiceIdentifier<T>,
+            scope: interfaces.BindingScope,
+            type: interfaces.BindingType,
+            value: any,
+            metadataKey: number|string|symbol|undefined,
+            metadataValue: any|undefined) => boolean;
+        setAncestors?: number|boolean;
+    }
     export type Bind = <T>(serviceIdentifier: ServiceIdentifier<T>) => BindingToSyntax<T>;
 
     export type Rebind = <T>(serviceIdentifier: ServiceIdentifier<T>) => BindingToSyntax<T>;

--- a/src/syntax/binding_on_syntax.ts
+++ b/src/syntax/binding_on_syntax.ts
@@ -9,7 +9,7 @@ class BindingOnSyntax<T> implements interfaces.BindingOnSyntax<T> {
         this._binding = binding;
     }
 
-    public onActivation(handler: (context: interfaces.Context, injectable: T) => T): interfaces.BindingWhenSyntax<T> {
+    public onActivation(handler: interfaces.OnActivationHandler<T>): interfaces.BindingWhenSyntax<T> {
         this._binding.onActivation = handler;
         return new BindingWhenSyntax<T>(this._binding);
     }

--- a/test/container/container.test.ts
+++ b/test/container/container.test.ts
@@ -804,4 +804,332 @@ describe("Container", () => {
 
     });
 
+    describe("Container onActivation", () => {
+        it("Should set Binding.onActivation for all bindings for default options", () => {
+            class Ninja {
+            }
+            class Katana {
+            }
+            const container = new Container();
+            container.bind(Ninja).toSelf();
+            container.bind(Katana).toSelf();
+
+            const onActivationHandler: interfaces.OnActivationHandler<any> = (c, i) => i;
+            container.onActivation(onActivationHandler);
+            getBindingDictionary(container).traverse((sid, bindings) => {
+                bindings.forEach((b) => {
+                    expect(b.onActivation).equal(onActivationHandler);
+                });
+            });
+        });
+        it("Should overwrite existing handler if removeExisting is true in options", () => {
+            class Ninja {
+            }
+            class Katana {
+            }
+            const container = new Container();
+
+            container.bind(Ninja).toSelf().onActivation((context, ninja) => ninja);
+            container.bind(Katana).toSelf();
+
+            const onActivationHandler: interfaces.OnActivationHandler<any> = (c, i) => i;
+            container.onActivation(onActivationHandler, {removeExisting: true});
+            getBindingDictionary(container).traverse((sid, bindings) => {
+                bindings.forEach((b) => {
+                    expect(b.onActivation).equal(onActivationHandler);
+                });
+            });
+        });
+
+        it("Should wrap Binding.onActivation if removeExisting is not true in options", () => {
+            const mockContext = {} as any;
+
+            const container = new Container();
+
+            const existingOnActivation = sinon.expectation.create().once().withExactArgs(mockContext, "Bound").returns("Existing");
+            container.bind<string>("ConstantValue").toConstantValue("Bound").onActivation(existingOnActivation);
+
+            const onActivationHandler = sinon.expectation.create()
+                .once().withExactArgs(mockContext, "Existing").returns("Global");
+            container.onActivation(onActivationHandler);
+
+            const constantValueBinding = getBindingDictionary(container).get("ConstantValue")[0] as interfaces.Binding<string>;
+            expect(constantValueBinding.onActivation!(mockContext, "Bound")).eqls("Global");
+            expect(onActivationHandler.calledAfter(existingOnActivation)).eqls(true);
+        });
+        describe("Filter binding values", () => {
+
+            type FilterArgs= [
+                interfaces.ServiceIdentifier<any>,
+                interfaces.BindingScope,
+                interfaces.BindingType,
+                any,
+                number|string|symbol|undefined,
+                any
+            ];
+            interface FilterBindingValuesTest {
+                description: string;
+                bind: (container: interfaces.Container) => void;
+                getExpectedFilterArgs: () => FilterArgs;
+            }
+            const constantValueBindingValueTest: FilterBindingValuesTest = (() => {
+                const constantValue = {some: "value"};
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind("ConstantValue").toConstantValue(constantValue),
+                    description: "Constant value",
+                    getExpectedFilterArgs: () =>  ["ConstantValue", "Transient", "ConstantValue", constantValue, undefined, undefined]
+                };
+                return test;
+            })();
+
+            const functionBindingValueTest: FilterBindingValuesTest = (() => {
+                const functionValue = () => true;
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind("Function").toFunction(functionValue),
+                    description: "Function",
+                    getExpectedFilterArgs: () =>  ["Function", "Transient", "Function", functionValue, undefined, undefined]
+                };
+                return test;
+            })();
+
+            const dynamicValueTest: FilterBindingValuesTest = (() => {
+                const dynamicValue = (c: interfaces.Context) => true;
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind("Dynamic").toDynamicValue(dynamicValue),
+                    description: "Dynamic value",
+                    getExpectedFilterArgs: () => ["Dynamic", "Transient", "DynamicValue", dynamicValue, undefined, undefined]
+                };
+                return test;
+            })();
+
+            const factoryTest: FilterBindingValuesTest = (() => {
+                const factoryCreator: interfaces.FactoryCreator<string> = (context) => (arg: string) => arg;
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind("Factory").toFactory(factoryCreator),
+                    description: "Factory",
+                    getExpectedFilterArgs: () => ["Factory", "Transient", "Factory", factoryCreator, undefined, undefined]
+                };
+                return test;
+            })();
+
+            const providerTest: FilterBindingValuesTest = (() => {
+                const providerCreator: interfaces.ProviderCreator<string> = (context) => (arg: string) => Promise.resolve(arg);
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind("Provider").toProvider(providerCreator),
+                    description: "Provider",
+                    getExpectedFilterArgs: () => ["Provider", "Transient", "Provider", providerCreator, undefined, undefined]
+                };
+                return test;
+            })();
+
+            const instanceTest: FilterBindingValuesTest = (() => {
+                class Ninja {
+                }
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind(Ninja).toSelf(),
+                    description: "Instance",
+                    getExpectedFilterArgs: () => [Ninja, "Transient", "Instance", Ninja, undefined, undefined]
+                };
+                return test;
+            })();
+
+            const autoFactoryTest: FilterBindingValuesTest = (() => {
+                interface IWeapon {}
+                class Katana implements IWeapon {
+                }
+                type IWeaponFactory = () => IWeapon;
+                const IWeaponFactory = Symbol.for("IWeaponFactory");
+                let autoFactoryBinding!: interfaces.Binding<any>;
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => {
+                        container.bind<Katana>(IWeaponFactory).toAutoFactory(Katana);
+                        autoFactoryBinding = getBindingDictionary(container).get(IWeaponFactory)[0];
+                    },
+                    description: "Auto factory",
+                    getExpectedFilterArgs: () => [
+                        IWeaponFactory,
+                        "Transient",
+                        "Factory",
+                        autoFactoryBinding.factory,
+                        undefined,
+                        undefined
+                    ]
+                };
+                return test;
+            })();
+
+            const serviceTest: FilterBindingValuesTest = (() => {
+                interface IWeapon {}
+                class Katana implements IWeapon {
+                }
+                let serviceBinding: interfaces.Binding<any>;
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => {
+                        container.bind<Katana>("Service").toService(Katana);
+                        serviceBinding = getBindingDictionary(container).get("Service")[0];
+                    },
+                    description: "Service",
+                    getExpectedFilterArgs: () => ["Service", "Transient", "DynamicValue", serviceBinding.dynamicValue, undefined, undefined]
+                };
+                return test;
+            })();
+
+            const constructorTest: FilterBindingValuesTest = (() => {
+                interface IWeapon {}
+                class Katana implements IWeapon {
+                }
+
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind<Katana>(Katana).toConstructor(Katana),
+                    description: "Constructor",
+                    getExpectedFilterArgs: () => [Katana, "Transient", "Constructor", Katana, undefined, undefined]
+                };
+                return test;
+            })();
+            const singletonScopeTest: FilterBindingValuesTest = (() => {
+                class Ninja {
+                }
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind(Ninja).toSelf().inSingletonScope(),
+                    description: "Singleton Scope",
+                    getExpectedFilterArgs: () => [Ninja, "Singleton", "Instance", Ninja, undefined, undefined]
+                };
+                return test;
+            })();
+            const requestScopeTest: FilterBindingValuesTest = (() => {
+                class Ninja {
+                }
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind(Ninja).toSelf().inRequestScope(),
+                    description: "Request Scope",
+                    getExpectedFilterArgs: () => [Ninja, "Request", "Instance", Ninja, undefined, undefined]
+                };
+                return test;
+            })();
+            const taggedTest: FilterBindingValuesTest = (() => {
+                class Ninja {
+                }
+                const test: FilterBindingValuesTest = {
+                    bind: (container) => container.bind(Ninja).toSelf().inRequestScope().whenTargetTagged("Key", "Value"),
+                    description: "Tagged",
+                    getExpectedFilterArgs: () => [Ninja, "Request", "Instance", Ninja, "Key", "Value"]
+                };
+                return test;
+            })();
+
+            [
+                constantValueBindingValueTest,
+                functionBindingValueTest,
+                dynamicValueTest,
+                factoryTest,
+                providerTest,
+                instanceTest,
+                autoFactoryTest,
+                serviceTest,
+                constructorTest,
+                singletonScopeTest,
+                requestScopeTest,
+                taggedTest
+            ].forEach( (t) => {
+                it(t.description, () => {
+                    const container = new Container();
+                    t.bind(container);
+                    let filterArgs!: FilterArgs;
+                    const filter: interfaces.GlobalOnActivationOptions<any>["filter"] = (
+                        sid, scope, type, value, metadataKey, metadataValue
+                    ) => {
+                        filterArgs = [sid, scope, type, value, metadataKey, metadataValue];
+                        return true;
+                    };
+                    container.onActivation((i) => i, { filter } );
+                    expect(filterArgs).to.have.members(t.getExpectedFilterArgs());
+                });
+            });
+        });
+        it("Should set Binding.onActivation only for Bindings that pass the filter", () => {
+            class Ninja {
+            }
+            class Katana {
+            }
+            const container = new Container();
+
+            container.bind(Ninja).toSelf();
+            container.bind(Katana).toSelf();
+
+            const onActivation: interfaces.OnActivationHandler<any> = (context, injected) => injected;
+            container.onActivation(onActivation, {filter: (serviceIdentifier) => serviceIdentifier === Katana});
+
+            const bindingDictionary = getBindingDictionary(container);
+            const katanaBinding = bindingDictionary.get(Katana)[0];
+            const ninjaBinding = bindingDictionary.get(Ninja)[0];
+
+            expect(!!ninjaBinding.onActivation).eqls(false);
+            expect(katanaBinding.onActivation).equal(onActivation);
+        });
+
+        describe("Setting onActivation on ancestor container bindings", () => {
+            interface AncestorsTest {
+                description: string;
+                expectParent: boolean;
+                expectGrandParent: boolean;
+                options?: interfaces.GlobalOnActivationOptions<any>;
+            }
+            const notSettingAncestorsTest: AncestorsTest = {
+                description: "Should not set onActivation for ancestor bindings if setAncestors is not true or > 0 in options",
+                expectGrandParent: false,
+                expectParent: false,
+            };
+            const allAncestorsTest: AncestorsTest = {
+                description: "Should set onActivation for all ancestor bindings if setAncestors is true in options",
+                expectGrandParent: true,
+                expectParent: true,
+                options: {setAncestors: true}
+            };
+            const ancestorLevelTest: AncestorsTest = {
+                description: "Should set onActivation for ancestor bindings up to provided level if setAncestors is number greater than 0",
+                expectGrandParent: false,
+                expectParent: true,
+                options: {setAncestors: 1}
+            };
+            [notSettingAncestorsTest, allAncestorsTest, ancestorLevelTest].forEach((t) => {
+                it(t.description, () => {
+                    class Samurai {
+
+                    }
+                    class Ninja {
+                    }
+                    class Katana {
+                    }
+                    const grandParentContainer = new Container();
+                    const parentContainer = grandParentContainer.createChild();
+                    const childContainer = parentContainer.createChild();
+
+                    grandParentContainer.bind(Samurai).toSelf();
+                    parentContainer.bind(Ninja).toSelf();
+                    childContainer.bind(Katana).toSelf();
+
+                    const onActivation: interfaces.OnActivationHandler<any> = (context, injected) => injected;
+                    childContainer.onActivation(onActivation, t.options);
+
+                    const grandParentBinding = getBindingDictionary(grandParentContainer).get(Samurai)[0];
+                    const parentBinding = getBindingDictionary(parentContainer).get(Ninja)[0];
+                    const childBinding = getBindingDictionary(childContainer).get(Katana)[0];
+
+                    if (t.expectGrandParent) {
+                        expect(grandParentBinding.onActivation).equal(onActivation);
+                    } else {
+                        expect(!!grandParentBinding.onActivation).equal(false);
+                    }
+
+                    if (t.expectParent) {
+                        expect(parentBinding.onActivation).equal(onActivation);
+                    } else {
+                        expect(!!parentBinding.onActivation).equal(false);
+                    }
+
+                    expect(childBinding.onActivation).equal(onActivation);
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added onActivation method to the Container class.  This will add the handler to all the bindings that match the filter and optionally will do the same for ancestor containers.  Default behaviour is to wrap existing handlers and there is an option to overwrite them.

## Related Issue

inversify/monorepo#1040

## Motivation and Context

As per inversify/monorepo#1040, where there is common onActivation options are to store the syntax in array and iterate or to use middleware.  This enables doing so with a single method call.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
TDD - checking that all/some of the Binding instances in the Container binding dictionary have had the onActivation handler present whether as is or wrapped with existing.  The filter too has been tested.

Tested on windows machine with current inversify test setup - mocha, sinon and chai.

<!--- see how your change affects other areas of the code, etc. -->
Change does not affect other code.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ x ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
- [ ] I have updated the changelog.

I will happily update the docs if the pull request is accepted.
