### PR TITLE
fix: update Target.isTagged to exclude optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Upgrade information for v4.x to v5.x
 
+### Fixed
+- Fix `Target.isTagged()` to exclude `optional` from tag injections #1190.
+
 ## [5.0.1] - 2018-10-17
 ### Added 
 - Updating constructor injection wiki document with concrete injection example #922

--- a/src/constants/metadata_keys.ts
+++ b/src/constants/metadata_keys.ts
@@ -30,3 +30,16 @@ export const DESIGN_PARAM_TYPES = "design:paramtypes";
 
 // used to identify postConstruct functions
 export const POST_CONSTRUCT = "post_construct";
+
+function getNonCustomTagKeys(): string[] {
+    return [
+        INJECT_TAG,
+        MULTI_INJECT_TAG,
+        NAME_TAG,
+        UNMANAGED_TAG,
+        NAMED_TAG,
+        OPTIONAL_TAG,
+    ];
+}
+
+export const NON_CUSTOM_TAG_KEYS: string[] = getNonCustomTagKeys();

--- a/src/planning/target.ts
+++ b/src/planning/target.ts
@@ -66,10 +66,11 @@ class Target implements interfaces.Target {
     public isTagged(): boolean {
         return this.metadata.some((m) =>
             (m.key !== METADATA_KEY.INJECT_TAG) &&
-                   (m.key !== METADATA_KEY.MULTI_INJECT_TAG) &&
-                   (m.key !== METADATA_KEY.NAME_TAG) &&
-                   (m.key !== METADATA_KEY.UNMANAGED_TAG) &&
-                   (m.key !== METADATA_KEY.NAMED_TAG));
+            (m.key !== METADATA_KEY.MULTI_INJECT_TAG) &&
+            (m.key !== METADATA_KEY.NAME_TAG) &&
+            (m.key !== METADATA_KEY.UNMANAGED_TAG) &&
+            (m.key !== METADATA_KEY.NAMED_TAG) &&
+            (m.key !== METADATA_KEY.OPTIONAL_TAG));
     }
 
     public isOptional(): boolean {

--- a/src/planning/target.ts
+++ b/src/planning/target.ts
@@ -64,13 +64,9 @@ class Target implements interfaces.Target {
     }
 
     public isTagged(): boolean {
-        return this.metadata.some((m) =>
-            (m.key !== METADATA_KEY.INJECT_TAG) &&
-            (m.key !== METADATA_KEY.MULTI_INJECT_TAG) &&
-            (m.key !== METADATA_KEY.NAME_TAG) &&
-            (m.key !== METADATA_KEY.UNMANAGED_TAG) &&
-            (m.key !== METADATA_KEY.NAMED_TAG) &&
-            (m.key !== METADATA_KEY.OPTIONAL_TAG));
+        return this.metadata.some(
+            (metadata) => METADATA_KEY.NON_CUSTOM_TAG_KEYS.every((key) => metadata.key !== key),
+        );
     }
 
     public isOptional(): boolean {
@@ -86,14 +82,12 @@ class Target implements interfaces.Target {
 
     public getCustomTags(): interfaces.Metadata[] | null {
         if (this.isTagged()) {
-            return this.metadata.filter((m) =>
-                (m.key !== METADATA_KEY.INJECT_TAG) &&
-                    (m.key !== METADATA_KEY.MULTI_INJECT_TAG) &&
-                    (m.key !== METADATA_KEY.NAME_TAG) &&
-                    (m.key !== METADATA_KEY.UNMANAGED_TAG) &&
-                    (m.key !== METADATA_KEY.NAMED_TAG));
+            return this.metadata.filter(
+                (metadata) => METADATA_KEY.NON_CUSTOM_TAG_KEYS.every((key) => metadata.key !== key),
+            );
+        } else {
+            return null;
         }
-        return null;
     }
 
     public matchesNamedTag(name: string): boolean {

--- a/test/bugs/issue_1190.test.ts
+++ b/test/bugs/issue_1190.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai";
+import { injectable, inject, optional, Container, named } from "../../src/inversify";
+
+describe("Issue 1190", () => {
+
+  it('should inject a katana as default weapon to ninja', () => {
+    const TYPES = {
+      Weapon: "Weapon"
+    };
+
+    const TAG = {
+      throwable: "throwable"
+    };
+
+    interface Weapon {
+      name: string;
+    }
+
+    @injectable()
+    class Katana implements Weapon {
+      public name: string;
+      public constructor() {
+        this.name = "Katana";
+      }
+    }
+
+    @injectable()
+    class Shuriken implements Weapon {
+      public name: string;
+      public constructor() {
+        this.name = "Shuriken";
+      }
+    }
+
+    @injectable()
+    class Ninja {
+      public name: string;
+      public katana: Katana;
+      public shuriken: Shuriken;
+      public constructor(
+        @inject(TYPES.Weapon) @optional() katana: Weapon,
+        @inject(TYPES.Weapon) @named(TAG.throwable) shuriken: Weapon
+      ) {
+        this.name = "Ninja";
+        this.katana = katana;
+        this.shuriken = shuriken;
+      }
+    }
+
+    const container = new Container();
+
+    container.bind<Weapon>(TYPES.Weapon).to(Katana).whenTargetIsDefault();
+    container.bind<Weapon>(TYPES.Weapon).to(Shuriken).whenTargetNamed(TAG.throwable);
+
+    container.bind<Ninja>("Ninja").to(Ninja);
+
+    const ninja = container.get<Ninja>("Ninja");
+
+    expect(ninja.katana).to.deep.eq(new Katana());
+  });
+});

--- a/test/planning/target.test.ts
+++ b/test/planning/target.test.ts
@@ -78,6 +78,29 @@ describe("Target", () => {
         target3.metadata.push(new Metadata("power", 5), new Metadata("speed", 5));
         expect(target3.isTagged()).to.be.eql(true);
 
+        const target4 = new Target(TargetTypeEnum.Variable, "", "Katana");
+        target4.metadata.push(new Metadata(METADATA_KEY.INJECT_TAG, "Katana"))
+        expect(target4.isTagged()).to.be.eql(false);
+
+        const target5 = new Target(TargetTypeEnum.Variable, "", "Katana");
+        target5.metadata.push(new Metadata(METADATA_KEY.MULTI_INJECT_TAG, "Katana"))
+        expect(target5.isTagged()).to.be.eql(false);
+
+        const target6 = new Target(TargetTypeEnum.Variable, "katanaName", "Katana");
+        target6.metadata.push(new Metadata(METADATA_KEY.NAME_TAG, "katanaName"))
+        expect(target6.isTagged()).to.be.eql(false);
+
+        const target7 = new Target(TargetTypeEnum.Variable, "", "Katana");
+        target7.metadata.push(new Metadata(METADATA_KEY.UNMANAGED_TAG, true))
+        expect(target7.isTagged()).to.be.eql(false);
+
+        const target8 = new Target(TargetTypeEnum.Variable, "katanaName", "Katana");
+        target8.metadata.push(new Metadata(METADATA_KEY.NAMED_TAG, "katanaName"))
+        expect(target8.isTagged()).to.be.eql(false);
+
+        const target9 = new Target(TargetTypeEnum.Variable, "", "Katana");
+        target9.metadata.push(new Metadata(METADATA_KEY.OPTIONAL_TAG, true))
+        expect(target9.isTagged()).to.be.eql(false);
     });
 
     it("Should be able to match tagged metadata", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

A binding with `optional` decorator should not be considered tagged just for that fact.
This PR adds `optional` to the list of decorators to exclude in order to determine whether or not a binding is tagged.

## Related Issue

#1190 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change allow to determine wheter or not a binding is tagged and avoid unexpected behavior such as the one described in the related issue.

## How Has This Been Tested?

- Tests has been added to cover the issue behavior

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
