### PR TITLE
Fix node typings in performance tests

### DIFF
--- a/test/features/request_scope.test.ts
+++ b/test/features/request_scope.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { Container, inject, injectable, named } from "../../src/inversify";
+import { performance } from 'perf_hooks';
 
 describe("inRequestScope", () => {
 

--- a/test/node/performance.test.ts
+++ b/test/node/performance.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import { Container } from "../../src/inversify";
+import { performance } from 'perf_hooks';
 
 describe("Performance", () => {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     "target": "es5",
     "types": [
       "mocha",
-      "reflect-metadata"
+      "reflect-metadata",
+      "node"
     ]
   },
   "exclude": [


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds `node` typings that enable importing `perf_hooks` in performance tests without compiler error.

Some more detail:
![image](https://user-images.githubusercontent.com/31600776/131145436-9436daa2-968c-46dc-a0ed-4f5d15bdf293.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the changelog.
