### PR TITLE
Update typescript compiler options  fix

### DIFF
--- a/src/container/module_activation_store.ts
+++ b/src/container/module_activation_store.ts
@@ -31,11 +31,11 @@ export class ModuleActivationStore implements interfaces.ModuleActivationStore {
   }
 
   private addActivationHandler(
-		moduleId: number,
-		serviceIdentifier: interfaces.ServiceIdentifier<unknown>,
-		activation: interfaces.BindingActivation<unknown>,
-		type: "activation" | "deactivation"
-	) {
+    moduleId: number,
+    serviceIdentifier: interfaces.ServiceIdentifier<unknown>,
+    activation: interfaces.BindingActivation<unknown>,
+    type: "activation" | "deactivation"
+  ) {
     const handlers = this._getModuleActivationHandlers(moduleId);
     const lookup = type === "activation" ? handlers.onActivations : handlers.onDeactivations;
     lookup.add(serviceIdentifier, activation);

--- a/src/container/module_activation_store.ts
+++ b/src/container/module_activation_store.ts
@@ -18,8 +18,8 @@ export class ModuleActivationStore implements interfaces.ModuleActivationStore {
     serviceIdentifier: interfaces.ServiceIdentifier<unknown>,
     onDeactivation: interfaces.BindingDeactivation<unknown>,
   ) {
-    this._getModuleActivationHandlers(moduleId)
-      .onDeactivations.add(serviceIdentifier, onDeactivation);
+    this.addActivationHandler(moduleId, serviceIdentifier, onDeactivation, 'deactivation');
+
   }
 
   public addActivation(
@@ -27,8 +27,18 @@ export class ModuleActivationStore implements interfaces.ModuleActivationStore {
     serviceIdentifier: interfaces.ServiceIdentifier<unknown>,
     onActivation: interfaces.BindingActivation<unknown>,
   ) {
-    this._getModuleActivationHandlers(moduleId)
-      .onActivations.add(serviceIdentifier, onActivation);
+    this.addActivationHandler(moduleId, serviceIdentifier, onActivation, 'activation');
+  }
+
+  private addActivationHandler(
+		moduleId: number,
+		serviceIdentifier: interfaces.ServiceIdentifier<unknown>,
+		activation: interfaces.BindingActivation<unknown>,
+		type: "activation" | "deactivation"
+	) {
+    const handlers = this._getModuleActivationHandlers(moduleId);
+    const lookup = type === "activation" ? handlers.onActivations : handlers.onDeactivations;
+    lookup.add(serviceIdentifier, activation);
   }
 
   public clone(): interfaces.ModuleActivationStore {

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -305,16 +305,17 @@ namespace interfaces {
     onDeactivation(fn: (injectable: T) => void | Promise<void>): BindingWhenSyntax<T>;
   }
 
+  export type Ancestor = NewableFunction | string;
   export interface BindingWhenSyntax<T> {
     when(constraint: (request: Request) => boolean): BindingOnSyntax<T>;
     whenTargetNamed(name: string | number | symbol): BindingOnSyntax<T>;
     whenTargetIsDefault(): BindingOnSyntax<T>;
     whenTargetTagged(tag: string | number | symbol, value: unknown): BindingOnSyntax<T>;
-    whenInjectedInto(parent: (NewableFunction | string)): BindingOnSyntax<T>;
+    whenInjectedInto(parent: Ancestor): BindingOnSyntax<T>;
     whenParentNamed(name: string | number | symbol): BindingOnSyntax<T>;
     whenParentTagged(tag: string | number | symbol, value: unknown): BindingOnSyntax<T>;
-    whenAnyAncestorIs(ancestor: (NewableFunction | string)): BindingOnSyntax<T>;
-    whenNoAncestorIs(ancestor: (NewableFunction | string)): BindingOnSyntax<T>;
+    whenAnyAncestorIs(ancestor: Ancestor): BindingOnSyntax<T>;
+    whenNoAncestorIs(ancestor: Ancestor): BindingOnSyntax<T>;
     whenAnyAncestorNamed(name: string | number | symbol): BindingOnSyntax<T>;
     whenAnyAncestorTagged(tag: string | number | symbol, value: unknown): BindingOnSyntax<T>;
     whenNoAncestorNamed(name: string | number | symbol): BindingOnSyntax<T>;

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -241,7 +241,7 @@ function plan(
     return context;
   } catch (error) {
     if (
-      isStackOverflowExeption(error)
+      isStackOverflowExeption(error) && context.plan
     ) {
       circularDependencyToException(context.plan.rootRequest);
     }

--- a/src/syntax/binding_when_syntax.ts
+++ b/src/syntax/binding_when_syntax.ts
@@ -1,6 +1,13 @@
 import { interfaces } from "../interfaces/interfaces";
 import { BindingOnSyntax } from "./binding_on_syntax";
-import { namedConstraint, taggedConstraint, traverseAncerstors, typeConstraint } from "./constraint_helpers";
+import {
+	buildSimpleDisallowConstraint,
+	buildSimpleAllowConstraint,
+	namedConstraint,
+	taggedConstraint,
+	traverseAncerstors,
+	typeConstraint,
+} from "./constraint_helpers";
 
 class BindingWhenSyntax<T> implements interfaces.BindingWhenSyntax<T> {
 
@@ -65,32 +72,23 @@ class BindingWhenSyntax<T> implements interfaces.BindingWhenSyntax<T> {
   }
 
   public whenAnyAncestorIs(ancestor: interfaces.Ancestor): interfaces.BindingOnSyntax<T> {
-    this._binding.constraint = (request: interfaces.Request | null) =>
-      request !== null && traverseAncerstors(request, typeConstraint(ancestor));
+    this._binding.constraint = buildSimpleAllowConstraint(ancestor, typeConstraint);
 
     return new BindingOnSyntax<T>(this._binding);
   }
 
   public whenNoAncestorIs(ancestor: interfaces.Ancestor): interfaces.BindingOnSyntax<T> {
-    this._binding.constraint = (request: interfaces.Request | null) =>
-      request !== null && !traverseAncerstors(request, typeConstraint(ancestor));
-
+    this._binding.constraint = buildSimpleDisallowConstraint(ancestor, typeConstraint);
     return new BindingOnSyntax<T>(this._binding);
   }
 
   public whenAnyAncestorNamed(name: string | number | symbol): interfaces.BindingOnSyntax<T> {
-
-    this._binding.constraint = (request: interfaces.Request | null) =>
-      request !== null && traverseAncerstors(request, namedConstraint(name));
-
+    this._binding.constraint = buildSimpleAllowConstraint(name, namedConstraint);
     return new BindingOnSyntax<T>(this._binding);
   }
 
   public whenNoAncestorNamed(name: string | number | symbol): interfaces.BindingOnSyntax<T> {
-
-    this._binding.constraint = (request: interfaces.Request | null) =>
-      request !== null && !traverseAncerstors(request, namedConstraint(name));
-
+    this._binding.constraint = buildSimpleDisallowConstraint(name, namedConstraint);
     return new BindingOnSyntax<T>(this._binding);
   }
 

--- a/src/syntax/binding_when_syntax.ts
+++ b/src/syntax/binding_when_syntax.ts
@@ -1,12 +1,12 @@
 import { interfaces } from "../interfaces/interfaces";
 import { BindingOnSyntax } from "./binding_on_syntax";
 import {
-	buildSimpleDisallowConstraint,
-	buildSimpleAllowConstraint,
-	namedConstraint,
-	taggedConstraint,
-	traverseAncerstors,
-	typeConstraint,
+  buildSimpleDisallowConstraint,
+  buildSimpleAllowConstraint,
+  namedConstraint,
+  taggedConstraint,
+  traverseAncerstors,
+  typeConstraint,
 } from "./constraint_helpers";
 
 class BindingWhenSyntax<T> implements interfaces.BindingWhenSyntax<T> {

--- a/src/syntax/binding_when_syntax.ts
+++ b/src/syntax/binding_when_syntax.ts
@@ -43,7 +43,7 @@ class BindingWhenSyntax<T> implements interfaces.BindingWhenSyntax<T> {
     return new BindingOnSyntax<T>(this._binding);
   }
 
-  public whenInjectedInto(parent: (NewableFunction | string)): interfaces.BindingOnSyntax<T> {
+  public whenInjectedInto(parent: interfaces.Ancestor): interfaces.BindingOnSyntax<T> {
     this._binding.constraint = (request: interfaces.Request | null) =>
       request !== null && typeConstraint(parent)(request.parentRequest);
 
@@ -64,14 +64,14 @@ class BindingWhenSyntax<T> implements interfaces.BindingWhenSyntax<T> {
     return new BindingOnSyntax<T>(this._binding);
   }
 
-  public whenAnyAncestorIs(ancestor: (NewableFunction | string)): interfaces.BindingOnSyntax<T> {
+  public whenAnyAncestorIs(ancestor: interfaces.Ancestor): interfaces.BindingOnSyntax<T> {
     this._binding.constraint = (request: interfaces.Request | null) =>
       request !== null && traverseAncerstors(request, typeConstraint(ancestor));
 
     return new BindingOnSyntax<T>(this._binding);
   }
 
-  public whenNoAncestorIs(ancestor: (NewableFunction | string)): interfaces.BindingOnSyntax<T> {
+  public whenNoAncestorIs(ancestor: interfaces.Ancestor): interfaces.BindingOnSyntax<T> {
     this._binding.constraint = (request: interfaces.Request | null) =>
       request !== null && !traverseAncerstors(request, typeConstraint(ancestor));
 

--- a/src/syntax/constraint_helpers.ts
+++ b/src/syntax/constraint_helpers.ts
@@ -52,21 +52,21 @@ const typeConstraint = (type: interfaces.Ancestor) => (request: interfaces.Reque
 /**
  * Creates a constraint building function for either permitting and disallowing constraints.
  * Specifying a value for `toBeConstrained` will restrict the type of function that can be used for `constraintFn`.
- * 
+ *
  * @param willBePermitting Whether the constraint builder function will be one which returns a permitting constraint.
  */
 const simpleConstraintBuilderBy =
-	(willBePermitting: boolean) =>
-	<TConstrained extends string | number | symbol | interfaces.Ancestor>(
-		toBeConstrained: TConstrained,
-		constraintFn: (toBeConstrained: TConstrained) => (request: interfaces.Request | null) => boolean
-	) =>
-	(request: interfaces.Request | null) =>
-		request !== null &&
-		(() => {
-			const constraintConditionHasBeenMet = traverseAncerstors(request, constraintFn(toBeConstrained));
-			return willBePermitting ? constraintConditionHasBeenMet : !constraintConditionHasBeenMet;
-		})();
+  (willBePermitting: boolean) =>
+  <TConstrained extends string | number | symbol | interfaces.Ancestor>(
+    toBeConstrained: TConstrained,
+    constraintFn: (toBeConstrained: TConstrained) => (request: interfaces.Request | null) => boolean
+  ) =>
+  (request: interfaces.Request | null) =>
+    request !== null &&
+    (() => {
+      const constraintConditionHasBeenMet = traverseAncerstors(request, constraintFn(toBeConstrained));
+      return willBePermitting ? constraintConditionHasBeenMet : !constraintConditionHasBeenMet;
+    })();
 
 /**
  * Builds a constraint which is an allowance (AT LEAST ONE ancestors MUST follow this condition).

--- a/src/syntax/constraint_helpers.ts
+++ b/src/syntax/constraint_helpers.ts
@@ -29,7 +29,7 @@ const taggedConstraint = (key: string | number | symbol) => (value: unknown) => 
 
 const namedConstraint = taggedConstraint(METADATA_KEY.NAMED_TAG);
 
-const typeConstraint = (type: (NewableFunction | string)) => (request: interfaces.Request | null) => {
+const typeConstraint = (type: interfaces.Ancestor) => (request: interfaces.Request | null) => {
 
   // Using index 0 because constraints are applied
   // to one binding at a time (see Planner class)


### PR DESCRIPTION
Fixes a Node 9/10 specific issue with the way that circular dependency errors are managed. The issue relates to an inability to access `rootRequest` on `context.plan` in the error management code because `context.plan` is `undefined`, which throws an unexpected error.