### PR TITLE
Update Readme to with new typescript version

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ $ npm install inversify reflect-metadata --save
 
 The InversifyJS type definitions are included in the inversify npm package.
 
-> :warning: **Important!** InversifyJS requires TypeScript >= 2.0 and the `experimentalDecorators`, `emitDecoratorMetadata`, `types` and `lib`
+> :warning: **Important!** InversifyJS requires TypeScript >= 4.4 and the `experimentalDecorators`, `emitDecoratorMetadata`, `types` and `lib`
 compilation options in your `tsconfig.json` file.
 
 ```js


### PR DESCRIPTION


## Description
As stated here https://github.com/inversify/InversifyJS/issues/1393#issuecomment-958002220 by @PodaruDragos, inversify needs a version of typescript greater or equal than 4.4. Please feel free to close it if this doesn't apply, I know you are busy and probably this will help



## Related Issue

https://github.com/inversify/InversifyJS/issues/1393#issuecomment-958002220

## Motivation and Context

I am trying to save time to new developers having the same problem that I had with typescript version

## How Has This Been Tested?

Ran the basic example protect with the correct version of typescript.

## Types of changes



- [X] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have updated the changelog.
