### PR TITLE
Allow arguments in `Newable` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Allow arguments in `Newable` interface #1423
 
 ### Fixed
 

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -38,7 +38,7 @@ namespace interfaces {
     Variable: interfaces.TargetType;
   }
 
-  export type Newable<T> = new (...args: never[]) => T;
+  export type Newable<T> = new (...args: any[]) => T;
 
   export interface Abstract<T> {
     prototype: T;

--- a/src/syntax/binding_to_syntax.ts
+++ b/src/syntax/binding_to_syntax.ts
@@ -12,7 +12,7 @@ class BindingToSyntax<T> implements interfaces.BindingToSyntax<T> {
     this._binding = binding;
   }
 
-  public to(constructor: new (...args: never[]) => T): interfaces.BindingInWhenOnSyntax<T> {
+  public to(constructor: new (...args: any[]) => T): interfaces.BindingInWhenOnSyntax<T> {
     this._binding.type = BindingTypeEnum.Instance;
     this._binding.implementationType = constructor;
     return new BindingInWhenOnSyntax<T>(this._binding);


### PR DESCRIPTION
## Description

Allow arguments in `Newable` interface.

## Related Issue

Closes #1423.

## Motivation and Context

There is no reason why they should not be allowed

## How Has This Been Tested?

N.A.

## Types of changes

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
