### PR TITLE
Allow toService to be bound to async service 

### DIFF
--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -331,6 +331,12 @@ class Container implements interfaces.Container {
     return this._get<T>(getArgs) as Promise<T> | T;
   }
 
+  public getMaybeAsync<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): Promise<T> | T {
+    const getArgs = this._getNotAllArgs(serviceIdentifier, false);
+
+    return this._get<T>(getArgs) as Promise<T> | T;
+  }
+
   public getTagged<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>, key: string | number | symbol, value: unknown): T {
     const getArgs = this._getNotAllArgs(serviceIdentifier, false, key, value);
 

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -208,6 +208,7 @@ namespace interfaces {
     getAllTagged<T>(serviceIdentifier: ServiceIdentifier<T>, key: string | number | symbol, value: unknown): T[];
     getAllNamed<T>(serviceIdentifier: ServiceIdentifier<T>, named: string | number | symbol): T[];
     getAsync<T>(serviceIdentifier: ServiceIdentifier<T>): Promise<T>;
+    getMaybeAsync<T>(serviceIdentifier: ServiceIdentifier<T>): Promise<T> | T
     getNamedAsync<T>(serviceIdentifier: ServiceIdentifier<T>, named: string | number | symbol): Promise<T>;
     getTaggedAsync<T>(serviceIdentifier: ServiceIdentifier<T>, key: string | number | symbol, value: unknown): Promise<T>;
     getAllAsync<T>(serviceIdentifier: ServiceIdentifier<T>): Promise<T[]>;

--- a/src/syntax/binding_to_syntax.ts
+++ b/src/syntax/binding_to_syntax.ts
@@ -93,7 +93,7 @@ class BindingToSyntax<T> implements interfaces.BindingToSyntax<T> {
 
   public toService(service: string | symbol | interfaces.Newable<T> | interfaces.Abstract<T>): void {
     this.toDynamicValue(
-      (context) => context.container.get<T>(service)
+      (context) => context.container.getMaybeAsync(service)
     );
   }
 

--- a/test/resolution/resolver.test.ts
+++ b/test/resolution/resolver.test.ts
@@ -2566,4 +2566,22 @@ describe("Resolve", () => {
     expect(serviceFromGetAsync).eql(asyncServiceDynamicResolvedValue);
     expect(serviceFromGet).eql(asyncServiceDynamicResolvedValue);
   });
+
+  it("Should resolve service with async @postConstruct()", async () => {
+    @injectable()
+    class B {
+      @postConstruct()
+      async init() {
+        //
+      }
+    }
+
+    const container = new Container()
+    container.bind(B).toSelf().inSingletonScope()
+    container.bind('X').toService(B)
+
+    const x = await container.getAsync('X');
+    const b = await container.getAsync(B);
+    expect(b).eql(x)
+  })
 });


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
toService method:
```
 public toService(service: string | symbol | interfaces.Newable<T> | interfaces.Abstract<T>): void {
    this.toDynamicValue(
      (context) => context.container.get<T>(service)
    );
  }
```
Was using get method that throws exception when it would return promise. It caused prevented resolution of service using `getAsync` method.
`getAsync` could not be used instead because it always return promise even when resolution returns simple value (`async` keyword on function have that effect)
Removal of `async` keyword would change `getAsync` result - it would work for clients using `await` because one can await simple value but it would break for clients calling `then`/`catch` because simple values does not have them.
New function `getMaybeAsync` was introduced instead to Container interface returning promise when resolved to promise and simple value when resolved to simple value.

If introduction of new interface method is not desired then I see another way to approach problem - by passing if resolution is sync/async through Context.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#1409

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->


toService binding were using Container.get method internally so it was throwing exception when the binding target was promise even if the resolution was also asynchroneous (getAsync)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Added new automated test case. 
All old test cases are passing. 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the changelog.

I will update changelog/documentation if general shape of PR is acceptable.