### PR TITLE
Testing Up to 100%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [6.0.2]
+
+### Added
+Brought tests up to 100% Code Coverage
+
+### Changed
+LazyIdentfier Tests
+
+### Fixed
+Less than 100% code coverage
+
 ## [6.0.1] - 2021-10-14
 ### Added
 - add API method for check dependency only in current container

--- a/test/annotation/inject.test.ts
+++ b/test/annotation/inject.test.ts
@@ -201,4 +201,9 @@ describe("@inject", () => {
     }).to.throw(`${ERROR_MSGS.UNDEFINED_INJECT_ANNOTATION("WithUndefinedInject")}`)
   });
 
+  it('Should unwrap LazyServiceIdentifer', () => {
+    const unwrapped = lazySwordId.unwrap();
+    expect(unwrapped).to.be.equal('Sword');
+  });
+
 });

--- a/test/syntax/binding_to_syntax.test.ts
+++ b/test/syntax/binding_to_syntax.test.ts
@@ -5,6 +5,7 @@ import * as ERROR_MSGS from "../../src/constants/error_msgs";
 import { BindingScopeEnum, BindingTypeEnum } from "../../src/constants/literal_types";
 import { interfaces } from "../../src/interfaces/interfaces";
 import { BindingToSyntax } from "../../src/syntax/binding_to_syntax";
+import sinon from "sinon";
 
 describe("BindingToSyntax", () => {
 
@@ -78,6 +79,17 @@ describe("BindingToSyntax", () => {
 
     expect(binding.type).eql(BindingTypeEnum.Factory);
     expect(binding.factory).not.to.eql(null);
+
+    const mockContext = {
+      container: {
+        getNamed: sinon.stub()
+      }
+    };
+
+    if (binding.factory !== null) {
+      binding.factory((mockContext as unknown as interfaces.Context))(ninjaIdentifier);
+      sinon.assert.calledOnce(mockContext.container.getNamed);
+    }
 
     bindingToSyntax.toProvider<Ninja>((context: interfaces.Context) =>
       () =>

--- a/test/syntax/binding_when_syntax.test.ts
+++ b/test/syntax/binding_when_syntax.test.ts
@@ -45,6 +45,20 @@ describe("BindingWhenSyntax", () => {
 
   });
 
+  it("Should have false constraint binding null request whenTargetIsDefault", () => {
+
+    interface Weapon {
+      name: string;
+    }
+
+    const shurikenBinding = new Binding<Weapon>("Weapon", BindingScopeEnum.Transient);
+    const shurikenBindingWhenSyntax = new BindingWhenSyntax<Weapon>(shurikenBinding);
+
+    shurikenBindingWhenSyntax.whenTargetIsDefault();
+    expect(shurikenBinding.constraint(null)).eql(false);
+
+  });
+
   it("Should be able to constraint a binding to a named target", () => {
 
     interface Ninja { }

--- a/test/utils/reflection.test.ts
+++ b/test/utils/reflection.test.ts
@@ -1,0 +1,59 @@
+import { expect } from "chai";
+import { injectable, inject, LazyServiceIdentifer, Container } from '../../src/inversify';
+import { getDependencies } from '../../src/planning/reflection_utils';
+import { MetadataReader } from "../../src/planning/metadata_reader";
+import sinon from "sinon";
+
+describe('Reflection Utilities Unit Tests', () => {
+
+    it('Should unwrap LazyServiceIdentifier in getConstructorArgsAsTarget', () => {
+
+        interface Ninja {
+            fight(): string;
+        }
+
+        interface Katana {
+            hit(): string;
+        }
+
+        @injectable()
+        class Katana implements Katana {
+            public hit() {
+                return "cut!";
+            }
+        }
+
+        const TYPES = {
+            Katana: Symbol.for("Katana"),
+            Ninja: Symbol.for("Ninja"),
+        };
+
+        @injectable()
+        class Ninja implements Ninja {
+
+        private _katana: Katana;
+
+        public constructor(
+            @inject(new LazyServiceIdentifer(() => TYPES.Katana)) katana: Katana,
+        ) {
+            this._katana = katana;
+        }
+
+        public fight() { return this._katana.hit(); }
+
+        }
+
+        const container = new Container();
+        container.bind<Ninja>(TYPES.Ninja).to(Ninja);
+        container.bind<Katana>(TYPES.Katana).to(Katana);
+
+        const unwrapSpy = sinon.spy(LazyServiceIdentifer.prototype, 'unwrap');
+
+        const dependencies = getDependencies(new MetadataReader(), Ninja);
+
+        expect(dependencies.length).to.be.eql(1);
+        sinon.assert.calledOnce(unwrapSpy);
+
+        sinon.restore();
+    });
+});


### PR DESCRIPTION
Brought Testing up to 100% Code Coverage
Removed Console Log
New Lines

The code coverage in the current state was not 100%. To start contributing I thought it'd be good to get this brought to 100% while investing deeper into the codebase.

## Description

- Tested LazyServiceIdentifier unwrap call.
- Tested unwrap LazyServiceIdentifier in getConstructorArgsAsTarget
- Removed Console Log in resolver test
- Tested the asynchronous unbinds for PromiseLike singletons
- Tested getNamed on binding factory
- Tested null binding contraint whenTargetIsDefault is called

## Related Issue

#1426 

## Motivation and Context

Getting my feet wet in contributing to InversifyJS. My team and I use this in our production platform and I would like to have more insight, knowledge and better knowing this core feature stays up to date.

## How Has This Been Tested?

Ran `npm test` over and over and over. Scanned for es-lint errors and made sure coverage was 100% in nyc HTML code coverage page.

## Types of changes

- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
