### PR TITLE
fix typo (`LazyServiceIdentifer` -> `LazyServiceIdentifier`)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13360,9 +13360,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mixin-deep": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13360,9 +13360,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mixin-deep": {

--- a/src/annotation/lazy_service_identifier.ts
+++ b/src/annotation/lazy_service_identifier.ts
@@ -1,8 +1,8 @@
 import { interfaces } from '../interfaces/interfaces';
 
-export type ServiceIdentifierOrFunc<T> = interfaces.ServiceIdentifier<T> | LazyServiceIdentifer<T>;
+export type ServiceIdentifierOrFunc<T> = interfaces.ServiceIdentifier<T> | LazyServiceIdentifier<T>;
 
-export class LazyServiceIdentifer<T = unknown> {
+export class LazyServiceIdentifier<T = unknown> {
   private _cb: () => interfaces.ServiceIdentifier<T>;
   public constructor(cb: () => interfaces.ServiceIdentifier<T>) {
     this._cb = cb;

--- a/src/constants/error_msgs.ts
+++ b/src/constants/error_msgs.ts
@@ -9,7 +9,7 @@ export const MISSING_INJECTABLE_ANNOTATION = 'Missing required @injectable annot
 export const MISSING_INJECT_ANNOTATION = 'Missing required @inject or @multiInject annotation in:';
 export const UNDEFINED_INJECT_ANNOTATION = (name: string) =>
   `@inject called with undefined this could mean that the class ${name} has ` +
-  'a circular dependency problem. You can use a LazyServiceIdentifer to  ' +
+  'a circular dependency problem. You can use a LazyServiceIdentifier to  ' +
   'overcome this limitation.';
 export const CIRCULAR_DEPENDENCY = 'Circular dependency found:';
 export const NOT_IMPLEMENTED = 'Sorry, this feature is not fully implemented yet.';

--- a/src/inversify.ts
+++ b/src/inversify.ts
@@ -9,6 +9,7 @@ export { tagged } from './annotation/tagged';
 export { named } from './annotation/named';
 export { inject } from './annotation/inject';
 export { LazyServiceIdentifier } from './annotation/lazy_service_identifier'
+export { LazyServiceIdentifier as LazyServiceIdentifer } from './annotation/lazy_service_identifier'
 export { optional } from './annotation/optional';
 export { unmanaged } from './annotation/unmanaged';
 export { multiInject } from './annotation/multi_inject';

--- a/src/inversify.ts
+++ b/src/inversify.ts
@@ -8,7 +8,7 @@ export { injectable } from './annotation/injectable';
 export { tagged } from './annotation/tagged';
 export { named } from './annotation/named';
 export { inject } from './annotation/inject';
-export { LazyServiceIdentifer } from './annotation/lazy_service_identifier'
+export { LazyServiceIdentifier } from './annotation/lazy_service_identifier'
 export { optional } from './annotation/optional';
 export { unmanaged } from './annotation/unmanaged';
 export { multiInject } from './annotation/multi_inject';

--- a/src/planning/reflection_utils.ts
+++ b/src/planning/reflection_utils.ts
@@ -1,4 +1,4 @@
-import { LazyServiceIdentifer } from '../annotation/lazy_service_identifier';
+import { LazyServiceIdentifier } from '../annotation/lazy_service_identifier';
 import * as ERROR_MSGS from '../constants/error_msgs';
 import { TargetTypeEnum } from '../constants/literal_types';
 import * as METADATA_KEY from '../constants/metadata_keys';
@@ -79,8 +79,8 @@ function getConstructorArgsAsTarget(
   const injectIdentifier = metadata.inject || metadata.multiInject;
   serviceIdentifier = (injectIdentifier ? injectIdentifier : serviceIdentifier) as interfaces.ServiceIdentifier<unknown> | undefined;
 
-  // we unwrap LazyServiceIdentifer wrappers to allow circular dependencies on symbols
-  if (serviceIdentifier instanceof LazyServiceIdentifer) {
+  // we unwrap LazyServiceIdentifier wrappers to allow circular dependencies on symbols
+  if (serviceIdentifier instanceof LazyServiceIdentifier) {
     serviceIdentifier = serviceIdentifier.unwrap();
   }
 

--- a/test/annotation/inject.test.ts
+++ b/test/annotation/inject.test.ts
@@ -9,7 +9,7 @@ declare function __param(paramIndex: number, decorator: ParameterDecorator): Cla
 import { expect } from 'chai';
 import { decorate } from '../../src/annotation/decorator_utils';
 import { inject } from '../../src/annotation/inject';
-import { LazyServiceIdentifer, ServiceIdentifierOrFunc } from '../../src/annotation/lazy_service_identifier';
+import { LazyServiceIdentifier, ServiceIdentifierOrFunc } from '../../src/annotation/lazy_service_identifier';
 import * as ERROR_MSGS from '../../src/constants/error_msgs';
 import * as METADATA_KEY from '../../src/constants/metadata_keys';
 import { interfaces } from '../../src/interfaces/interfaces';
@@ -22,7 +22,7 @@ class Katana implements Katana { }
 class Shuriken implements Shuriken { }
 class Sword implements Sword { }
 
-const lazySwordId = new LazyServiceIdentifer(() => 'Sword');
+const lazySwordId = new LazyServiceIdentifier(() => 'Sword');
 
 class DecoratedWarrior {
 
@@ -204,7 +204,7 @@ describe('@inject', () => {
     }).to.throw(`${ERROR_MSGS.UNDEFINED_INJECT_ANNOTATION('WithUndefinedInject')}`)
   });
 
-  it('Should unwrap LazyServiceIdentifer', () => {
+  it('Should unwrap LazyServiceIdentifier', () => {
     const unwrapped = lazySwordId.unwrap();
     expect(unwrapped).to.be.equal('Sword');
   });

--- a/test/inversify.test.ts
+++ b/test/inversify.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as ERROR_MSGS from '../src/constants/error_msgs';
 import { interfaces } from '../src/interfaces/interfaces';
-import { Container, ContainerModule, decorate, inject, injectable, LazyServiceIdentifer, multiInject, named, tagged, targetName, typeConstraint, unmanaged } from '../src/inversify';
+import { Container, ContainerModule, decorate, inject, injectable, LazyServiceIdentifier, multiInject, named, tagged, targetName, typeConstraint, unmanaged } from '../src/inversify';
 
 describe('InversifyJS', () => {
 
@@ -282,7 +282,7 @@ describe('InversifyJS', () => {
 
   });
 
-  it('Should be able to wrap Symbols with LazyServiceIdentifer', () => {
+  it('Should be able to wrap Symbols with LazyServiceIdentifier', () => {
 
     interface Ninja {
       fight(): string;
@@ -324,8 +324,8 @@ describe('InversifyJS', () => {
       private _shuriken: Shuriken;
 
       public constructor(
-        @inject(new LazyServiceIdentifer(() => TYPES.Katana)) katana: Katana,
-        @inject(new LazyServiceIdentifer(() => TYPES.Shuriken)) shuriken: Shuriken
+        @inject(new LazyServiceIdentifier(() => TYPES.Katana)) katana: Katana,
+        @inject(new LazyServiceIdentifier(() => TYPES.Shuriken)) shuriken: Shuriken
       ) {
         this._katana = katana;
         this._shuriken = shuriken;

--- a/test/utils/reflection.test.ts
+++ b/test/utils/reflection.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { injectable, inject, LazyServiceIdentifer, Container } from '../../src/inversify';
+import { injectable, inject, LazyServiceIdentifier, Container } from '../../src/inversify';
 import { getDependencies } from '../../src/planning/reflection_utils';
 import { MetadataReader } from "../../src/planning/metadata_reader";
 import sinon from "sinon";
@@ -34,7 +34,7 @@ describe('Reflection Utilities Unit Tests', () => {
         private _katana: Katana;
 
         public constructor(
-            @inject(new LazyServiceIdentifer(() => TYPES.Katana)) katana: Katana,
+            @inject(new LazyServiceIdentifier(() => TYPES.Katana)) katana: Katana,
         ) {
             this._katana = katana;
         }
@@ -47,7 +47,7 @@ describe('Reflection Utilities Unit Tests', () => {
         container.bind<Ninja>(TYPES.Ninja).to(Ninja);
         container.bind<Katana>(TYPES.Katana).to(Katana);
 
-        const unwrapSpy = sinon.spy(LazyServiceIdentifer.prototype, 'unwrap');
+        const unwrapSpy = sinon.spy(LazyServiceIdentifier.prototype, 'unwrap');
 
         const dependencies = getDependencies(new MetadataReader(), Ninja);
 

--- a/wiki/circular_dependencies.md
+++ b/wiki/circular_dependencies.md
@@ -4,11 +4,11 @@
 
 If you have a circular dependency between two modules and you use the `@inject(SomeClass)` annotation. At runtime, one module will be parsed before the other and the decorator could be invoked with `@inject(SomeClass /* SomeClass = undefined*/)`. InversifyJS will throw the following exception:
 
-> @inject called with undefined this could mean that the class ${name} has a circular dependency problem. You can use a LazyServiceIdentifer to overcome this limitation.
+> @inject called with undefined this could mean that the class ${name} has a circular dependency problem. You can use a LazyServiceIdentifier to overcome this limitation.
 
 There are two ways to overcome this limitation:
 
-- Use a `LazyServiceIdentifer`. The lazy identifier doesn't delay the injection of the dependencies and all dependencies are injected when the class instance is created. However, it does delay the access to the property identifier (solving the module issue). An example of this can be found in [our unit tests](https://github.com/krzkaczor/InversifyJS/blob/a53bf2cbee65803b197998c1df496c3be84731d9/test/inversify.test.ts#L236-L300).
+- Use a `LazyServiceIdentifier`. The lazy identifier doesn't delay the injection of the dependencies and all dependencies are injected when the class instance is created. However, it does delay the access to the property identifier (solving the module issue). An example of this can be found in [our unit tests](https://github.com/krzkaczor/InversifyJS/blob/a53bf2cbee65803b197998c1df496c3be84731d9/test/inversify.test.ts#L236-L300).
 
 - Use the `@lazyInject` decorator. This decorator is part of the [`inversify-inject-decorators`](https://github.com/inversify/inversify-inject-decorators) module. The `@lazyInject` decorator delays the injection of the dependencies until they are actually used, this takes place after a class instance has been created.
 

--- a/wiki/container_api.md
+++ b/wiki/container_api.md
@@ -559,7 +559,7 @@ Restore container state to last snapshot.
 Save the state of the container to be later restored with the restore method.
 ## container.unbind(serviceIdentifier: interfaces.ServiceIdentifier\<unknown>): void
 
-Remove all bindings binded in this container to the service identifer.  This will result in the [deactivation process](https://github.com/inversify/InversifyJS/blob/master/wiki/deactivation_handler.md).
+Remove all bindings binded in this container to the service identifier.  This will result in the [deactivation process](https://github.com/inversify/InversifyJS/blob/master/wiki/deactivation_handler.md).
 
 ## container.unbindAsync(serviceIdentifier: interfaces.ServiceIdentifier\<unknown>): Promise\<void>
 

--- a/wiki/deactivation_handler.md
+++ b/wiki/deactivation_handler.md
@@ -24,7 +24,7 @@ It's possible to add a deactivation handler in multiple ways
 - Adding the handler to a binding.
 - Adding the handler to the class through the [preDestroy decorator](./pre_destroy.md).
 
-Handlers added to the container are the first ones to be resolved. Any handler added to a child container is called before the ones added to their parent. Relevant bindings from the container are called next and finally the `preDestroy` method is called. In the example above, relevant bindings are those bindings bound to the unbinded "Destroyable" service identifer.
+Handlers added to the container are the first ones to be resolved. Any handler added to a child container is called before the ones added to their parent. Relevant bindings from the container are called next and finally the `preDestroy` method is called. In the example above, relevant bindings are those bindings bound to the unbinded "Destroyable" service identifier.
 
 The example below demonstrates call order.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

changes interface `LazyServiceIdentifer` name to `LazyServiceIdentifier`

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
