### PR TITLE
fix: include source-map related files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,3 @@
-src
-**/*.js.map
 test
 typings
 bundled

--- a/package.json
+++ b/package.json
@@ -71,5 +71,5 @@
   },
   "sideEffects": false,
   "types": "lib/inversify.d.ts",
-  "version": "6.0.1"
+  "version": "6.0.2"
 }


### PR DESCRIPTION
fix: include source-map related files

## Description
In Wepack5+, deps using source map but published exclude those files will receive lots of warnings.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

this PR will publish required files which will prevent developers using webpack5 annoyed by source map warnings.


## Types of changes


- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
