### PR TITLE
Implement the proposed fix from issue #1290

### DIFF
--- a/src/annotation/unmanaged.ts
+++ b/src/annotation/unmanaged.ts
@@ -3,7 +3,7 @@ import { Metadata } from '../planning/metadata';
 import { tagParameter, DecoratorTarget } from './decorator_utils';
 
 function unmanaged() {
-  return function (target: DecoratorTarget, targetKey: string, index: number) {
+  return function (target: DecoratorTarget, targetKey: string | undefined, index: number) {
     const metadata = new Metadata(METADATA_KEY.UNMANAGED_TAG, true);
     tagParameter(target, targetKey, index, metadata);
   };


### PR DESCRIPTION
Implements the proposed fix from issue #1290 to satisfy tighter parameter type checking in latest versions of TypeScript. 

## Description

Without this change, if strict type checking is enabled in the latest versions of TypeScript, usages of a `@unmanaged()` decorator would cause the following error:

```
Argument of type 'undefined' is not assignable to parameter of type 'string'.
```

This can be seen using the most recently nightly builds of TypeScript 5.0.0 from late January 2023 onwards. 

## Related Issue

#1290

## Motivation and Context

Avoid compilation error in latest versions of TypeScript.

## How Has This Been Tested?


## Types of changes

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [NA] My change requires a change to the documentation.
- [NA] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have updated the changelog.
