### PR TITLE
Fix `@targetName()` signature on TypeScript 5

### DIFF
--- a/src/annotation/target_name.ts
+++ b/src/annotation/target_name.ts
@@ -3,7 +3,7 @@ import { Metadata } from '../planning/metadata';
 import { tagParameter, DecoratorTarget } from './decorator_utils';
 
 function targetName(name: string) {
-  return function (target: DecoratorTarget, targetKey: string, index: number) {
+  return function (target: DecoratorTarget, targetKey: string | undefined, index: number) {
     const metadata = new Metadata(METADATA_KEY.NAME_TAG, name);
     tagParameter(target, targetKey, index, metadata);
   };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Title. Basically just makes it accept an undefined value for `targetKey`, which stops TypeScript from complaining about it.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#1556 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

I want to upgrade Typescript to v5 and use `@targetName()`.

See https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#more-accurate-type-checking-for-parameter-decorators-in-constructors-under-experimentaldecorators

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Not a functional change, but rather a type change. That said, `npm test `still passes.
Furthermore, TypeScript v5.x.x no longer shows errors when using `@targetName()`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the changelog.
