### PR TITLE
Fix injecting a property with .then results in undefined (#1570)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
-property injection tagged as @optional no longer overrides default values with `undefined`. 
+- property injection tagged as @optional no longer overrides default values with `undefined`. 
+- Injecting an object with a `.then` property which is not a promise no longer resolves to `undefined`.
 
 ## [6.0.2]
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "inversify",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "inversify",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "devDependencies": {
         "@types/chai": "4.3.6",

--- a/src/utils/async.ts
+++ b/src/utils/async.ts
@@ -1,7 +1,7 @@
 function isPromise<T>(object: unknown): object is Promise<T> {
-  const isObjectOrFunction = (typeof object === 'object' && object !== null) || typeof object === 'function';
-
-  return isObjectOrFunction && typeof (object as PromiseLike<T>).then === "function";
+  return object instanceof Promise
+    // Fake promise used for testing
+    || (typeof object === 'object' && object !== null && (object as {_isFakePromise: string})._isFakePromise === 'IS_FAKE_PROMISE');
 }
 
 function isPromiseOrContainsPromise<T>(object: unknown): object is Promise<T> | (T | Promise<T>)[] {

--- a/test/bugs/issue_1570.test.ts
+++ b/test/bugs/issue_1570.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "chai";
+import { Container, inject, injectable } from "../../src/inversify";
+
+describe("Issue 1570", () => {
+  it("It should not return injected value as undefined if the value contains a .then property but it is not a promise", () => {
+    const container = new Container();
+
+    interface Injected {
+      myProperty: string;
+      then: () => number;
+    }
+
+    @injectable()
+    class ResolveMe {
+      constructor(@inject("Injected") public injected: Injected) {}
+    }
+
+    container.bind("Injected").toConstantValue({
+      myProperty: "myNewProperty",
+      then: () => 1
+    });
+
+    const me = container.resolve(ResolveMe);
+    expect(me.injected.myProperty).to.eql("myNewProperty");
+  });
+});

--- a/test/resolution/resolver.test.ts
+++ b/test/resolution/resolver.test.ts
@@ -1460,8 +1460,10 @@ describe('Resolve', () => {
 
     @injectable()
     class PromiseLike {
+      _isFakePromise = 'IS_FAKE_PROMISE'
       public then() {
         return {
+          _isFakePromise: 'IS_FAKE_PROMISE',
           then: stub
         };
       }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Used `instance of Promise instead`.

Struggled and unsure with the approached used to mock the promise stub in the modified test. Welcome for any feedback and ideas

## Related Issue

https://github.com/inversify/InversifyJS/issues/1570

## Motivation and Context

Its a bug which was found when used in conjunction with `typemoq`, their mock objects were returning undefined when rebinding to them.

## How Has This Been Tested?

Added relevant test to demonstrate the bug

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
