### PR TITLE
feat: strongly-typed `Container`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Optional strong typing for `Container`
 
 ### Changed
 

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -173,7 +173,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
   }
 
   // Registers a type binding
-  public bind<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public bind<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
   ): interfaces.BindingToSyntax<B> {
     const scope = this.options.defaultScope || BindingScopeEnum.Transient;
@@ -182,14 +182,14 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return new BindingToSyntax<B>(binding);
   }
 
-  public rebind<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public rebind<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
   ): interfaces.BindingToSyntax<B> {
     this.unbind(serviceIdentifier);
     return this.bind(serviceIdentifier);
   }
 
-  public async rebindAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public async rebindAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
   ): Promise<interfaces.BindingToSyntax<B>> {
     await this.unbindAsync(serviceIdentifier);
@@ -197,7 +197,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
   }
 
   // Removes a type binding from the registry by its key
-  public unbind<K extends interfaces.ContainerIdentifier<T>>(serviceIdentifier: K): void {
+  public unbind<K extends interfaces.MappedServiceIdentifier<T>>(serviceIdentifier: K): void {
     if (this._bindingDictionary.hasKey(serviceIdentifier)) {
       const bindings = this._bindingDictionary.get(serviceIdentifier);
 
@@ -207,7 +207,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     this._removeServiceFromDictionary(serviceIdentifier);
   }
 
-  public async unbindAsync<K extends interfaces.ContainerIdentifier<T>>(serviceIdentifier: K): Promise<void> {
+  public async unbindAsync<K extends interfaces.MappedServiceIdentifier<T>>(serviceIdentifier: K): Promise<void> {
     if (this._bindingDictionary.hasKey(serviceIdentifier)) {
       const bindings = this._bindingDictionary.get(serviceIdentifier);
 
@@ -238,14 +238,14 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     this._bindingDictionary = new Lookup<Binding<unknown>>();
   }
 
-  public onActivation<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public onActivation<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     onActivation: interfaces.BindingActivation<B>,
   ): void {
     this._activations.add(serviceIdentifier, onActivation as interfaces.BindingActivation<unknown>);
   }
 
-  public onDeactivation<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public onDeactivation<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     onDeactivation: interfaces.BindingDeactivation<B>,
   ): void {
@@ -253,7 +253,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
   }
 
   // Allows to check if there are bindings available for serviceIdentifier
-  public isBound<K extends interfaces.ContainerIdentifier<T>>(serviceIdentifier: K): boolean {
+  public isBound<K extends interfaces.MappedServiceIdentifier<T>>(serviceIdentifier: K): boolean {
     let bound = this._bindingDictionary.hasKey(serviceIdentifier);
     if (!bound && this.parent) {
       bound = this.parent.isBound(serviceIdentifier as any);
@@ -262,11 +262,11 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
   }
 
   // check binding dependency only in current container
-  public isCurrentBound<K extends interfaces.ContainerIdentifier<T>>(serviceIdentifier: K): boolean {
+  public isCurrentBound<K extends interfaces.MappedServiceIdentifier<T>>(serviceIdentifier: K): boolean {
     return this._bindingDictionary.hasKey(serviceIdentifier);
   }
 
-  public isBoundNamed<K extends interfaces.ContainerIdentifier<T>>(
+  public isBoundNamed<K extends interfaces.MappedServiceIdentifier<T>>(
     serviceIdentifier: K,
     named: string | number | symbol,
 ): boolean {
@@ -274,7 +274,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
   }
 
   // Check if a binding with a complex constraint is available without throwing a error. Ancestors are also verified.
-  public isBoundTagged<K extends interfaces.ContainerIdentifier<T>>(
+  public isBoundTagged<K extends interfaces.MappedServiceIdentifier<T>>(
     serviceIdentifier: K,
     key: string | number | symbol,
     value: unknown,
@@ -338,13 +338,13 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
   // Resolves a dependency by its runtime identifier
   // The runtime identifier must be associated with only one binding
   // use getAll when the runtime identifier is associated with multiple bindings
-  public get<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(serviceIdentifier: K): B {
+  public get<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(serviceIdentifier: K): B {
     const getArgs = this._getNotAllArgs(serviceIdentifier, false);
 
     return this._getButThrowIfAsync(getArgs) as B;
   }
 
-  public async getAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public async getAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
   ): Promise<B> {
     const getArgs = this._getNotAllArgs(serviceIdentifier, false);
@@ -352,7 +352,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return this._get(getArgs) as Promise<B> | B;
   }
 
-  public getTagged<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getTagged<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     key: string | number | symbol,
     value: unknown,
@@ -362,7 +362,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return this._getButThrowIfAsync(getArgs) as B;
   }
 
-  public async getTaggedAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public async getTaggedAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     key: string | number | symbol,
     value: unknown,
@@ -372,14 +372,14 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return this._get(getArgs) as Promise<B> | B;
   }
 
-  public getNamed<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getNamed<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     named: string | number | symbol,
   ): B {
     return this.getTagged(serviceIdentifier, METADATA_KEY.NAMED_TAG, named);
   }
 
-  public getNamedAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getNamedAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     named: string | number | symbol,
   ): Promise<B> {
@@ -388,7 +388,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
 
   // Resolves a dependency by its runtime identifier
   // The runtime identifier can be associated with one or multiple bindings
-  public getAll<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getAll<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
   ): B[] {
     const getArgs = this._getAllArgs(serviceIdentifier);
@@ -396,7 +396,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return this._getButThrowIfAsync(getArgs) as B[];
   }
 
-  public getAllAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getAllAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
   ): Promise<B[]> {
     const getArgs = this._getAllArgs(serviceIdentifier);
@@ -404,7 +404,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return this._getAll(getArgs) as Promise<B[]>;
   }
 
-  public getAllTagged<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getAllTagged<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     key: string | number | symbol,
     value: unknown,
@@ -414,7 +414,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return this._getButThrowIfAsync(getArgs) as B[];
   }
 
-  public getAllTaggedAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getAllTaggedAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     key: string | number | symbol,
     value: unknown,
@@ -424,14 +424,14 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return this._getAll(getArgs) as Promise<B[]>;
   }
 
-  public getAllNamed<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getAllNamed<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     named: string | number | symbol,
   ): B[] {
     return this.getAllTagged(serviceIdentifier, METADATA_KEY.NAMED_TAG, named);
   }
 
-  public getAllNamedAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  public getAllNamedAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     named: string | number | symbol,
   ): Promise<B[]> {
@@ -550,7 +550,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
       (bindingToSyntax as unknown as { _binding: { moduleId: interfaces.ContainerModuleBase['id'] } } )._binding.moduleId = moduleId;
     };
 
-    const getBindFunction = <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    const getBindFunction = <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       moduleId: interfaces.ContainerModuleBase['id'],
     ) =>
       (serviceIdentifier: K) => {
@@ -559,22 +559,22 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
         return bindingToSyntax as BindingToSyntax<B>;
       };
 
-    const getUnbindFunction = <K extends interfaces.ContainerIdentifier<T>>() =>
+    const getUnbindFunction = <K extends interfaces.MappedServiceIdentifier<T>>() =>
       (serviceIdentifier: K) => {
         return this.unbind(serviceIdentifier);
       };
 
-    const getUnbindAsyncFunction = <K extends interfaces.ContainerIdentifier<T>>() =>
+    const getUnbindAsyncFunction = <K extends interfaces.MappedServiceIdentifier<T>>() =>
       (serviceIdentifier: K) => {
         return this.unbindAsync(serviceIdentifier);
       };
 
-    const getIsboundFunction = <K extends interfaces.ContainerIdentifier<T>>() =>
+    const getIsboundFunction = <K extends interfaces.MappedServiceIdentifier<T>>() =>
       (serviceIdentifier: K) => {
         return this.isBound(serviceIdentifier)
       };
 
-    const getRebindFunction = <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    const getRebindFunction = <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       moduleId: interfaces.ContainerModuleBase['id'],
     ) =>
       (serviceIdentifier: K) => {
@@ -583,7 +583,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
         return bindingToSyntax as BindingToSyntax<B>;
       };
 
-    const getOnActivationFunction = <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    const getOnActivationFunction = <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       moduleId: interfaces.ContainerModuleBase['id'],
     ) =>
       (serviceIdentifier: K, onActivation: interfaces.BindingActivation<B>) => {
@@ -591,7 +591,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
         this.onActivation(serviceIdentifier, onActivation);
       }
 
-    const getOnDeactivationFunction = <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    const getOnDeactivationFunction = <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       moduleId: interfaces.ContainerModuleBase['id'],
     ) =>
       (serviceIdentifier: K, onDeactivation: interfaces.BindingDeactivation<B>) => {
@@ -610,7 +610,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     });
 
   }
-  private _getAll<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  private _getAll<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     getArgs: GetArgs<B>,
   ): Promise<B[]> {
     return Promise.all(this._get<B>(getArgs) as (Promise<B> | B)[]);
@@ -618,7 +618,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
   // Prepares arguments required for resolution and
   // delegates resolution to _middleware if available
   // otherwise it delegates resolution to _planAndResolve
-  private _get<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  private _get<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     getArgs: GetArgs<B>,
   ): interfaces.ContainerResolution<B> {
     const planAndResolveArgs: interfaces.NextArgs<B> = {
@@ -637,7 +637,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return this._planAndResolve<B>()(planAndResolveArgs);
   }
 
-  private _getButThrowIfAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  private _getButThrowIfAsync<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     getArgs: GetArgs<B>,
   ): (B | B[]) {
     const result = this._get<B>(getArgs);
@@ -649,7 +649,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return result as (B | B[]);
   }
 
-  private _getAllArgs<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  private _getAllArgs<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
   ): GetArgs<B> {
     const getAllArgs: GetArgs<B> = {
@@ -661,7 +661,7 @@ class Container<T extends interfaces.BindingMap = any, P extends interfaces.Bind
     return getAllArgs;
   }
 
-  private _getNotAllArgs<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+  private _getNotAllArgs<B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
     serviceIdentifier: K,
     isMultiInject: boolean,
     key?: string | number | symbol | undefined,

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -48,12 +48,12 @@ namespace interfaces {
 
   export type IfAny<T, Y, N> = 0 extends (1 & T) ? Y : N;
 
-  export type PropertyServiceIdentifier = (string | symbol);
-  export type ServiceIdentifier<T = unknown> = (PropertyServiceIdentifier | Newable<T> | Abstract<T>);
-  export type BindingMap = Record<PropertyServiceIdentifier, any>;
-  export type BindingMapKey<T extends BindingMap> = keyof T & PropertyServiceIdentifier;
-  export type ContainerIdentifier<T extends BindingMap> = IfAny<T, ServiceIdentifier, BindingMapKey<T>>;
-  export type ContainerBinding<T extends BindingMap, K extends ContainerIdentifier<T> = any> = K extends keyof T ? T[K] :
+  export type BindingMapProperty = (string | symbol);
+  export type ServiceIdentifier<T = unknown> = (string | symbol | Newable<T> | Abstract<T>);
+  export type BindingMap = Record<BindingMapProperty, any>;
+  export type BindingMapKey<T extends BindingMap> = keyof T & BindingMapProperty;
+  export type MappedServiceIdentifier<T extends BindingMap> = IfAny<T, ServiceIdentifier, BindingMapKey<T>>;
+  export type ContainerBinding<T extends BindingMap, K extends MappedServiceIdentifier<T> = any> = K extends keyof T ? T[K] :
     K extends Newable<infer C> ? C :
     K extends Abstract<infer D> ? D : never;
 
@@ -210,59 +210,59 @@ namespace interfaces {
     unbindAllAsync(): Promise<void>;
     isBound: IsBound<T>;
     isCurrentBound: IsBound<T>;
-    isBoundNamed: <K extends ContainerIdentifier<T>>(serviceIdentifier: K, named: PropertyKey) => boolean;
-    isBoundTagged: <K extends interfaces.ContainerIdentifier<T>>(
+    isBoundNamed: <K extends MappedServiceIdentifier<T>>(serviceIdentifier: K, named: PropertyKey) => boolean;
+    isBoundTagged: <K extends interfaces.MappedServiceIdentifier<T>>(
       serviceIdentifier: K,
       key: PropertyKey,
       value: unknown,
     ) => boolean;
-    get: <B extends ContainerBinding<T, K>, K extends ContainerIdentifier<T> = any>(serviceIdentifier: K) => B;
-    getNamed: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    get: <B extends ContainerBinding<T, K>, K extends MappedServiceIdentifier<T> = any>(serviceIdentifier: K) => B;
+    getNamed: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       named: PropertyKey,
     ) => B;
-    getTagged: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    getTagged: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       key: PropertyKey,
       value: unknown,
     ) => B;
-    getAll: <B extends ContainerBinding<T, K>, K extends ContainerIdentifier<T> = any>(serviceIdentifier: K) => B[];
-    getAllTagged: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    getAll: <B extends ContainerBinding<T, K>, K extends MappedServiceIdentifier<T> = any>(serviceIdentifier: K) => B[];
+    getAllTagged: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       key: PropertyKey,
       value: unknown,
     ) => B[];
-    getAllNamed: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    getAllNamed: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       named: PropertyKey,
     ) => B[];
-    getAsync: <B extends ContainerBinding<T, K>, K extends ContainerIdentifier<T> = any>(
+    getAsync: <B extends ContainerBinding<T, K>, K extends MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
     ) => Promise<B>;
-    getNamedAsync: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    getNamedAsync: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       named: PropertyKey,
     ) => Promise<B>;
-    getTaggedAsync: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    getTaggedAsync: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       key: PropertyKey,
       value: unknown,
     ) => Promise<B>;
-    getAllAsync: <B extends ContainerBinding<T, K>, K extends ContainerIdentifier<T> = any>(serviceIdentifier: K) => Promise<B[]>;
-    getAllTaggedAsync: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    getAllAsync: <B extends ContainerBinding<T, K>, K extends MappedServiceIdentifier<T> = any>(serviceIdentifier: K) => Promise<B[]>;
+    getAllTaggedAsync: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       key: PropertyKey,
       value: unknown,
     ) => Promise<B[]>;
-    getAllNamedAsync: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.ContainerIdentifier<T> = any>(
+    getAllNamedAsync: <B extends interfaces.ContainerBinding<T, K>, K extends interfaces.MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       named: PropertyKey,
     ) => Promise<B[]>;
-    onActivation<B extends ContainerBinding<T, K>, K extends ContainerIdentifier<T> = any>(
+    onActivation<B extends ContainerBinding<T, K>, K extends MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       onActivation: BindingActivation<B>,
     ): void;
-    onDeactivation<B extends ContainerBinding<T, K>, K extends ContainerIdentifier<T> = any>(
+    onDeactivation<B extends ContainerBinding<T, K>, K extends MappedServiceIdentifier<T> = any>(
       serviceIdentifier: K,
       onDeactivation: BindingDeactivation<B>,
     ): void;
@@ -279,19 +279,19 @@ namespace interfaces {
   }
 
   export type Bind<T extends BindingMap = any> =
-    <B extends ContainerBinding<T, K>, K extends ContainerIdentifier<T> = any>(serviceIdentifier: K) => BindingToSyntax<B>;
+    <B extends ContainerBinding<T, K>, K extends MappedServiceIdentifier<T> = any>(serviceIdentifier: K) => BindingToSyntax<B>;
 
   export type Rebind<T extends BindingMap = any> = Bind<T>;
 
   export type RebindAsync<T extends BindingMap = any> =
-  <B extends ContainerBinding<T, K>, K extends ContainerIdentifier<T> = any>(serviceIdentifier: K) => Promise<BindingToSyntax<B>>;
+  <B extends ContainerBinding<T, K>, K extends MappedServiceIdentifier<T> = any>(serviceIdentifier: K) => Promise<BindingToSyntax<B>>;
 
-  export type Unbind<T extends BindingMap = any> = <K extends ContainerIdentifier<T>>(serviceIdentifier: K) => void;
+  export type Unbind<T extends BindingMap = any> = <K extends MappedServiceIdentifier<T>>(serviceIdentifier: K) => void;
 
   export type UnbindAsync<T extends BindingMap = any> =
-    <K extends ContainerIdentifier<T>>(serviceIdentifier: K) => Promise<void>;
+    <K extends MappedServiceIdentifier<T>>(serviceIdentifier: K) => Promise<void>;
 
-  export type IsBound<T extends BindingMap = any> = <K extends ContainerIdentifier<T>>(serviceIdentifier: K) => boolean;
+  export type IsBound<T extends BindingMap = any> = <K extends MappedServiceIdentifier<T>>(serviceIdentifier: K) => boolean;
 
   export interface ContainerModuleBase {
     id: number;

--- a/src/planning/planner.ts
+++ b/src/planning/planner.ts
@@ -217,9 +217,9 @@ function getBindings<T>(
   return bindings;
 }
 
-function plan(
+function plan<T extends interfaces.BindingMap>(
   metadataReader: interfaces.MetadataReader,
-  container: interfaces.Container,
+  container: interfaces.Container<T>,
   isMultiInject: boolean,
   targetType: interfaces.TargetType,
   serviceIdentifier: interfaces.ServiceIdentifier,
@@ -245,8 +245,8 @@ function plan(
 
 }
 
-function createMockRequest(
-  container: interfaces.Container,
+function createMockRequest<T extends interfaces.BindingMap>(
+  container: interfaces.Container<T>,
   serviceIdentifier: interfaces.ServiceIdentifier,
   key: string | number | symbol,
   value: unknown

--- a/src/syntax/binding_to_syntax.ts
+++ b/src/syntax/binding_to_syntax.ts
@@ -82,7 +82,7 @@ class BindingToSyntax<T> implements interfaces.BindingToSyntax<T> {
   public toAutoNamedFactory<T2>(serviceIdentifier: interfaces.ServiceIdentifier<T2>): BindingWhenOnSyntax<T> {
     this._binding.type = BindingTypeEnum.Factory;
     this._binding.factory = (context) => {
-      return (named: unknown) => context.container.getNamed<T2>(serviceIdentifier, named as string);
+      return (named: unknown) => context.container.getNamed(serviceIdentifier, named as string);
     };
     return new BindingWhenOnSyntax<T>(this._binding);
   }

--- a/test/interfaces/interfaces.test.ts
+++ b/test/interfaces/interfaces.test.ts
@@ -1,0 +1,124 @@
+import { interfaces } from '../../src/interfaces/interfaces';
+import {Container, injectable} from '../../src/inversify';
+import {expect} from 'chai';
+
+describe('interfaces', () => {
+  @injectable()
+  class Foo {
+    foo: string = '';
+  }
+
+  @injectable()
+  class Bar {
+    bar: string = '';
+  }
+
+  describe('Container', () => {
+    let foo: Foo;
+    let foos: Foo[];
+
+    beforeEach(() => {
+      // tslint:disable-next-line: no-unused-expression
+      foo;
+      // tslint:disable-next-line: no-unused-expression
+      foos;
+    });
+
+    describe('no binding map', () => {
+      let container: interfaces.Container;
+
+      beforeEach(() => {
+        container = new Container();
+      });
+
+      describe('bind()', () => {
+        it('binds without a type argument', () => {
+          container.bind('foo').to(Foo);
+          container.bind(Foo).to(Foo);
+        });
+
+        it('checks bindings with an explicit type argument', () => {
+          container.bind<Foo>('foo').to(Foo);
+          // @ts-expect-error :: can't bind Bar to Foo
+          container.bind<Foo>('foo').to(Bar);
+        });
+
+        it('binds a class as a service identifier', () => {
+          container.bind(Foo).to(Foo);
+          // @ts-expect-error :: can't bind Bar to Foo
+          container.bind(Foo).to(Bar);
+        });
+      });
+
+      describe('get()', () => {
+        beforeEach(() => {
+          container.bind('foo').to(Foo);
+          container.bind('bar').to(Bar);
+          container.bind(Foo).to(Foo);
+          container.bind(Bar).to(Bar);
+        });
+
+        it('gets an anonymous binding', () => {
+          foo = container.get('foo');
+        });
+
+        it('enforces type arguments', () => {
+          foo = container.get<Foo>('foo');
+          // @ts-expect-error :: can't assign Bar to Foo
+          foo = container.get<Bar>('bar');
+        });
+
+        it('gets a class identifier', () => {
+          foo = container.get(Foo);
+          // @ts-expect-error :: can't assign Bar to Foo
+          foo = container.get(Bar);
+        });
+
+        it('gets all', () => {
+          foos = container.getAll<Foo>('foo');
+          // @ts-expect-error :: can't assign Bar to Foo
+          foos = container.getAll<Bar>('bar');
+        });
+      });
+    });
+
+    describe('binding map', () => {
+      let container: interfaces.Container<{foo: Foo; bar: Bar}>;
+
+      beforeEach(() => {
+        container = new Container();
+      });
+
+      describe('bind()', () => {
+        it('enforces strict bindings', () => {
+          container.bind('foo').to(Foo);
+          // @ts-expect-error :: can't bind Bar to Foo
+          container.bind('foo').to(Bar);
+          // @ts-expect-error :: unknown service identifier
+          container.bind('unknown').to(Foo);
+        });
+      });
+
+      describe('get()', () => {
+        beforeEach(() => {
+          container.bind('foo').to(Foo);
+          container.bind('bar').to(Bar);
+        });
+
+        it('enforces strict bindings', () => {
+          foo = container.get('foo');
+          // @ts-expect-error :: can't assign Bar to Foo
+          foo = container.get('bar');
+          // @ts-expect-error :: unknown service identifier
+          expect(() => container.get('unknown')).to.throw('No matching bindings');
+        });
+
+        it('gets all', () => {
+          foos = container.getAll('foo');
+          // @ts-expect-error :: can't assign Bar to Foo
+          foos = container.getAll('bar');
+        });
+      });
+    });
+  });
+});

--- a/wiki/container_typing.md
+++ b/wiki/container_typing.md
@@ -1,0 +1,21 @@
+# Strong Container typing
+
+The `Container` can take an optional type argument defining a mapping of service identifiers to types. If defined, this
+will add strong type-checking when declaring bindings, and when retrieving them.
+
+For example:
+
+```ts
+type IdentifierMap = {
+  foo: Foo;
+  bar: Bar;
+};
+
+const container = new Container<IdentifierMap>;
+
+container.bind('foo').to(Foo); // ok
+container.bind('foo').to(Bar); // error
+
+const foo: Foo = container.get('foo') // ok
+const bar: Bar = container.get('foo') // error
+```

--- a/wiki/readme.md
+++ b/wiki/readme.md
@@ -17,6 +17,7 @@ Welcome to the InversifyJS wiki!
 - [Container API](./container_api.md)
 - [Declaring container modules](./container_modules.md)
 - [Container snapshots](./container_snapshots.md)
+- [Strong Container typing](./container_typing.md)
 - [Controlling the scope of the dependencies](./scope.md)
 - [Declaring optional dependencies](./optional_dependencies.md)
 - [Injecting a constant or dynamic value](./value_injection.md)


### PR DESCRIPTION
## Description

This is a non-breaking change, affecting only TypeScript types, and doesn't change the implementation in any way.

### Motivation

`inversify` already has some basic support for types when binding, and retrieving bindings.

However, the type support requires manual intervention from developers, and can be error-prone.

For example, the following code will happily compile, even though the types here are inconsistent:

```ts
container.bind<Bar>('bar').to(Bar);
const foo = container.get<Foo>('bar')
```

Furthermore, this proposal paves the way for [type-safe injection][1], which will be added once this change is in.

### Improved type safety

This change adds an optional type parameter to the `Container`, which takes an identifier map as an argument. For example:

```ts
type IdentifierMap = {
  foo: Foo;
  bar: Bar;
};

const container = new Container<IdentifierMap>;
```

If a `Container` is typed like this, we now get strong typing both when binding, and getting bindings:

```ts
const container = new Container<IdentifierMap>;

container.bind('foo').to(Foo); // ok
container.bind('foo').to(Bar); // error

const foo: Foo = container.get('foo') // ok
const bar: Bar = container.get('foo') // error
```

This also has the added benefit of no longer needing to pass around service identifier constants: the strings (or symbols) are all strongly typed, and will fail compilation if an incorrect one is used.

### Non-breaking

This change aims to make no breaks to the existing types, so any `Container` without an argument should continue to work as it did before.

[1]: https://github.com/inversify/InversifyJS/issues/788#issuecomment-2209341498

## Related Issue

https://github.com/inversify/InversifyJS/issues/788

## How Has This Been Tested?

- added tests to this test suite, which passes
- based on type definitions we've been using in Production ourselves

## Types of changes

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
