### PR TITLE
Update npmignore with .nyc_output

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,9 +20,10 @@ CODE_OF_CONDUCT.md
 tslint.json
 wallaby.js
 .auditignore
-.travis.yml
+.nyc_output
 .github
 .gitignore
-.vscode
 .publishrc
+.travis.yml
+.vscode
 type_definitions


### PR DESCRIPTION
## Description
- Updated npmignore with `.nyc_output`.

## Motivation and Context
Ignore code coverage folder in npm releases.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the changelog.
