### PR TITLE
Add missing typescript esm types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Updated ESM build with missing types.
 
 ## [6.1.2]
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   "scripts": {
     "build": "npm run build:lib && npm run build:amd && npm run build:es && npm run build:es6",
     "build:amd": "tsc -p src/tsconfig-amd.json",
-    "build:es": "tsc -p src/tsconfig-es.json",
+    "build:es": "tsc -p src/tsconfig-es.json && node ./scripts/writeEsmPackageJson.mjs ./es",
     "build:es6": "tsc -p src/tsconfig-es6.json",
     "build:lib": "tsc -p src/tsconfig.json",
     "clean": "rimraf amd es es6 lib",

--- a/scripts/writeEsmPackageJson.mjs
+++ b/scripts/writeEsmPackageJson.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import { argv } from 'node:process';
+import path from 'node:path';
+import { writeFile } from 'node:fs/promises';
+
+/**
+ * @param {string} path
+ * @returns {Promise<boolean>}
+ */
+async function pathExists(path) {
+  try {
+    await fs.access(path);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+const directory = argv[2];
+
+if (directory === undefined) {
+  throw new Error('Expected a path');
+}
+
+const directoryExists = await pathExists(directory);
+
+if (!directoryExists) {
+  throw new Error(`Path ${directory} not found`);
+}
+
+const filePath = path.join(directory, 'package.json');
+
+const packageJsonFileContent = JSON.stringify(
+  {
+    type: 'module',
+  },
+  undefined,
+  2,
+);
+
+await writeFile(filePath, packageJsonFileContent);

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,8 +4,6 @@
   ],
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "composite": true,
-    "declaration": true,
     "outDir": "../lib",
     "rootDir": "."
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "allowUnusedLabels": false,
     "alwaysStrict": true,
     "assumeChangesOnlyAffectDirectDependencies": true,
+    "declaration": true,
     "emitDecoratorMetadata": true,
     "esModuleInterop": true,
     "exactOptionalPropertyTypes": true,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds missing esm type declaration files.

## Motivation and Context

This PR solves an issue for node16+ users targeting inversify as an esm module.

## How Has This Been Tested?
https://arethetypeswrong.github.io/ passes with the tar generated.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
