### PR TITLE
Update service bindings to avoid caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed container to properly resolve async `.toService` bindings.
+- Fixed `.toService` binding to properly disable caching any values.
 
 ## [6.1.4]
 

--- a/test/bugs/issue_1416.test.ts
+++ b/test/bugs/issue_1416.test.ts
@@ -1,0 +1,42 @@
+import { describe, it } from 'mocha';
+import sinon from 'sinon';
+
+import { Container, injectable, preDestroy } from '../../src/inversify';
+
+describe('Issue 1416', () => {
+  it('should allow providing default values on optional bindings', async () => {
+    @injectable()
+    class Test1 {
+      public stub: sinon.SinonStub<unknown[], void> = sinon.stub();
+
+      @preDestroy()
+      public destroy() {
+        this.stub();
+      }
+    }
+
+    @injectable()
+    class Test2 {
+      public destroy(): void {}
+    }
+
+    @injectable()
+    class Test3 {
+      public destroy(): void {}
+    }
+
+    const container: Container = new Container({ defaultScope: 'Singleton' });
+
+    container.bind(Test1).toSelf();
+    container.bind(Test2).toService(Test1);
+    container.bind(Test3).toService(Test1);
+
+    const test1: Test1 = container.get(Test1);
+    container.get(Test2);
+    container.get(Test3);
+
+    container.unbindAll();
+
+    sinon.assert.calledOnce(test1.stub);
+  });
+});

--- a/wiki/tagged_bindings.md
+++ b/wiki/tagged_bindings.md
@@ -1,7 +1,7 @@
 # Tagged bindings
 
 We can use tagged bindings to fix `AMBIGUOUS_MATCH` errors when two or more
-concretions have been bound to an abstraction. Notice how the  constructor
+concretions have been bound to an abstraction. Notice how the constructor
 arguments of the `Ninja` class have been annotated using the `@tagged` decorator:
 
 ```ts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Updated `toService` bindings to disable caching values.

## Related Issue
Fixes #1416

## How Has This Been Tested?
Tests run succesfully.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
