### PR TITLE
Fix null property access at getBaseClassDependencyCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+- Fixed unexpected property access while running planning checks on injected base types.
 
 ## [6.1.5]
 

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -36,6 +36,14 @@ export default [
         dir: './lib/esm',
         format: 'esm',
         sourcemap: true,
+        sourcemapPathTransform: (relativeSourcePath) => {
+          // Rollup seems to generate source maps pointing to the wrong directory. Ugly patch to fix it
+          if (relativeSourcePath.startsWith('../')) {
+            return relativeSourcePath.slice(3);
+          } else {
+            return relativeSourcePath;
+          }
+        },
       },
     ],
     plugins: [

--- a/src/planning/reflection_utils.ts
+++ b/src/planning/reflection_utils.ts
@@ -3,6 +3,7 @@ import { getTargets } from '@inversifyjs/core';
 
 import * as METADATA_KEY from '../constants/metadata_keys';
 import { interfaces } from '../interfaces/interfaces';
+import { getBaseType } from '../utils/get_base_type';
 import { getFunctionName } from '../utils/serialization';
 import { Metadata } from './metadata';
 
@@ -17,39 +18,36 @@ function getBaseClassDependencyCount(
   metadataReader: interfaces.MetadataReader,
   func: NewableFunction,
 ): number {
-  const baseConstructor: NewableFunction =
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-    Object.getPrototypeOf(func.prototype).constructor as NewableFunction;
-  if (baseConstructor !== (Object as unknown as NewableFunction)) {
-    // get targets for base class
+  const baseConstructor: Newable | undefined = getBaseType(func);
 
-    const targets: interfaces.Target[] = getTargets(metadataReader)(
-      baseConstructor as Newable,
-    );
-
-    // get unmanaged metadata
-    const metadata: interfaces.Metadata[][] = targets.map(
-      (t: interfaces.Target) =>
-        t.metadata.filter(
-          (m: interfaces.Metadata) => m.key === METADATA_KEY.UNMANAGED_TAG,
-        ),
-    );
-
-    // Compare the number of constructor arguments with the number of
-    // unmanaged dependencies unmanaged dependencies are not required
-    const unmanagedCount: number = ([] as Metadata[]).concat.apply(
-      [],
-      metadata,
-    ).length;
-    const dependencyCount: number = targets.length - unmanagedCount;
-
-    if (dependencyCount > 0) {
-      return dependencyCount;
-    } else {
-      return getBaseClassDependencyCount(metadataReader, baseConstructor);
-    }
-  } else {
+  if (baseConstructor === undefined || baseConstructor === Object) {
     return 0;
+  }
+
+  // get targets for base class
+  const targets: interfaces.Target[] =
+    getTargets(metadataReader)(baseConstructor);
+
+  // get unmanaged metadata
+  const metadata: interfaces.Metadata[][] = targets.map(
+    (t: interfaces.Target) =>
+      t.metadata.filter(
+        (m: interfaces.Metadata) => m.key === METADATA_KEY.UNMANAGED_TAG,
+      ),
+  );
+
+  // Compare the number of constructor arguments with the number of
+  // unmanaged dependencies unmanaged dependencies are not required
+  const unmanagedCount: number = ([] as Metadata[]).concat.apply(
+    [],
+    metadata,
+  ).length;
+  const dependencyCount: number = targets.length - unmanagedCount;
+
+  if (dependencyCount > 0) {
+    return dependencyCount;
+  } else {
+    return getBaseClassDependencyCount(metadataReader, baseConstructor);
   }
 }
 

--- a/src/test/utils/get_base_type.test.ts
+++ b/src/test/utils/get_base_type.test.ts
@@ -1,0 +1,50 @@
+import { Newable } from '@inversifyjs/common';
+import { expect } from 'chai';
+
+import { getBaseType } from '../../utils/get_base_type';
+
+describe(getBaseType.name, () => {
+  describe('having a type with base type', () => {
+    let baseTypeFixture: Newable;
+    let typeFixture: Newable;
+
+    before(() => {
+      class BaseType {}
+
+      baseTypeFixture = BaseType;
+      typeFixture = class extends BaseType {};
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      before(() => {
+        result = getBaseType(typeFixture);
+      });
+
+      it('should return base type', () => {
+        expect(result).to.eq(baseTypeFixture);
+      });
+    });
+  });
+
+  describe('having a type with no base type', () => {
+    let typeFixture: Newable;
+
+    before(() => {
+      typeFixture = Object;
+    });
+
+    describe('when called', () => {
+      let result: unknown;
+
+      before(() => {
+        result = getBaseType(typeFixture);
+      });
+
+      it('should return undefined', () => {
+        expect(result).to.eq(undefined);
+      });
+    });
+  });
+});

--- a/src/utils/get_base_type.ts
+++ b/src/utils/get_base_type.ts
@@ -1,7 +1,7 @@
 import { Newable } from '@inversifyjs/common';
 
 interface Prototype {
-  constructor?: Newable;
+  constructor: Newable;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type

--- a/src/utils/get_base_type.ts
+++ b/src/utils/get_base_type.ts
@@ -1,0 +1,16 @@
+import { Newable } from '@inversifyjs/common';
+
+interface Prototype {
+  constructor: Newable;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+export function getBaseType(type: Function): Newable | undefined {
+  const prototype: Prototype | null = Object.getPrototypeOf(
+    type.prototype,
+  ) as Prototype | null;
+
+  const baseType: Newable | undefined = prototype?.constructor;
+
+  return baseType;
+}

--- a/src/utils/get_base_type.ts
+++ b/src/utils/get_base_type.ts
@@ -1,7 +1,7 @@
 import { Newable } from '@inversifyjs/common';
 
 interface Prototype {
-  constructor: Newable;
+  constructor?: Newable;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixed unexpected property access on null valeus when running planning checks on injected base classes.
- Fixed ESM sourcemap links.

## Related Issue
#1664

## How Has This Been Tested?
- Tests run successfully.
- Sourcemaps target right ts files.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
