### PR TITLE
Update container.getAll with options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Added `interfaces.GetAllOptions`.
 
 ### Changed
+- Updated `container.getAll` with `options` optional param.
+- Updated `container.getAllAsync` with `options` optional param.
 
 ### Fixed
 

--- a/src/container/container.ts
+++ b/src/container/container.ts
@@ -447,16 +447,20 @@ class Container implements interfaces.Container {
 
   // Resolves a dependency by its runtime identifier
   // The runtime identifier can be associated with one or multiple bindings
-  public getAll<T>(serviceIdentifier: interfaces.ServiceIdentifier<T>): T[] {
-    const getArgs: GetArgs<T> = this._getAllArgs(serviceIdentifier);
+  public getAll<T>(
+    serviceIdentifier: interfaces.ServiceIdentifier<T>,
+    options?: interfaces.GetAllOptions,
+  ): T[] {
+    const getArgs: GetArgs<T> = this._getAllArgs(serviceIdentifier, options);
 
     return this._getButThrowIfAsync<T>(getArgs) as T[];
   }
 
   public async getAllAsync<T>(
     serviceIdentifier: interfaces.ServiceIdentifier<T>,
+    options?: interfaces.GetAllOptions,
   ): Promise<T[]> {
-    const getArgs: GetArgs<T> = this._getAllArgs(serviceIdentifier);
+    const getArgs: GetArgs<T> = this._getAllArgs(serviceIdentifier, options);
 
     return this._getAll(getArgs);
   }
@@ -830,9 +834,10 @@ class Container implements interfaces.Container {
 
   private _getAllArgs<T>(
     serviceIdentifier: interfaces.ServiceIdentifier<T>,
+    options: interfaces.GetAllOptions | undefined,
   ): GetArgs<T> {
     const getAllArgs: GetArgs<T> = {
-      avoidConstraints: true,
+      avoidConstraints: !(options?.enforceBindingConstraints ?? false),
       isMultiInject: true,
       serviceIdentifier,
     };

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -215,6 +215,10 @@ namespace interfaces {
     skipBaseClassChecks?: boolean;
   }
 
+  export interface GetAllOptions {
+    enforceBindingConstraints?: boolean;
+  }
+
   export interface Container {
     id: number;
     parent: Container | null;
@@ -251,7 +255,10 @@ namespace interfaces {
       key: string | number | symbol,
       value: unknown,
     ): T;
-    getAll<T>(serviceIdentifier: ServiceIdentifier<T>): T[];
+    getAll<T>(
+      serviceIdentifier: ServiceIdentifier<T>,
+      options?: GetAllOptions,
+    ): T[];
     getAllTagged<T>(
       serviceIdentifier: ServiceIdentifier<T>,
       key: string | number | symbol,
@@ -271,7 +278,10 @@ namespace interfaces {
       key: string | number | symbol,
       value: unknown,
     ): Promise<T>;
-    getAllAsync<T>(serviceIdentifier: ServiceIdentifier<T>): Promise<T[]>;
+    getAllAsync<T>(
+      serviceIdentifier: ServiceIdentifier<T>,
+      options?: GetAllOptions,
+    ): Promise<T[]>;
     getAllTaggedAsync<T>(
       serviceIdentifier: ServiceIdentifier<T>,
       key: string | number | symbol,

--- a/src/test/bugs/issue_1670.test.ts
+++ b/src/test/bugs/issue_1670.test.ts
@@ -1,0 +1,105 @@
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import { Container, interfaces } from '../../index';
+
+type StorageConfig = 'all' | 'disk' | 'redis';
+
+type Storage = 'disk-storage' | 'redis-storage';
+
+/**
+ * Creates a condition function for storage bindings based on a specific storage configuration.
+ * This function is used with Inversify's `.when` method to dynamically control which bindings apply.
+ *
+ * @param config - The specific storage type to match. Cannot be 'all' since it acts as a wildcard.
+ * @returns A function that checks whether the current storage configuration matches the provided type.
+ */
+function isStorageConfig(
+  config: Exclude<StorageConfig, 'all'>,
+): (request: interfaces.Request) => boolean {
+  return ({ parentContext: { container } }: interfaces.Request) => {
+    const storageConfig: StorageConfig =
+      container.get<StorageConfig>('storage-config');
+    return storageConfig === 'all' || storageConfig === config;
+  };
+}
+
+describe('Issue 1670', () => {
+  it('should get expected services with custom binding constraints (disk)', async () => {
+    const config: StorageConfig = 'disk';
+    const expectedStorageServices: Storage[] = ['disk-storage'];
+
+    const container: Container = new Container({ defaultScope: 'Singleton' });
+
+    container
+      .bind<StorageConfig>('storage-config')
+      .toDynamicValue(() => config);
+
+    container
+      .bind<Storage>('storage')
+      .toDynamicValue(() => 'disk-storage')
+      .when(isStorageConfig('disk'));
+
+    container
+      .bind<Storage>('storage')
+      .toDynamicValue(() => 'redis-storage')
+      .when(isStorageConfig('redis'));
+
+    expect(
+      container.getAll<Storage>('storage', { enforceBindingConstraints: true }),
+    ).to.deep.eq(expectedStorageServices);
+  });
+
+  it('should get expected services with custom binding constraints (redis)', async () => {
+    const config: StorageConfig = 'redis';
+    const expectedStorageServices: Storage[] = ['redis-storage'];
+
+    const container: Container = new Container({ defaultScope: 'Singleton' });
+
+    container
+      .bind<StorageConfig>('storage-config')
+      .toDynamicValue(() => config);
+
+    container
+      .bind<Storage>('storage')
+      .toDynamicValue(() => 'disk-storage')
+      .when(isStorageConfig('disk'));
+
+    container
+      .bind<Storage>('storage')
+      .toDynamicValue(() => 'redis-storage')
+      .when(isStorageConfig('redis'));
+
+    expect(
+      container.getAll<Storage>('storage', { enforceBindingConstraints: true }),
+    ).to.deep.eq(expectedStorageServices);
+  });
+
+  it('should get expected services with custom binding constraints (all)', async () => {
+    const config: StorageConfig = 'all';
+    const expectedStorageServices: Storage[] = [
+      'disk-storage',
+      'redis-storage',
+    ];
+
+    const container: Container = new Container({ defaultScope: 'Singleton' });
+
+    container
+      .bind<StorageConfig>('storage-config')
+      .toDynamicValue(() => config);
+
+    container
+      .bind<Storage>('storage')
+      .toDynamicValue(() => 'disk-storage')
+      .when(isStorageConfig('disk'));
+
+    container
+      .bind<Storage>('storage')
+      .toDynamicValue(() => 'redis-storage')
+      .when(isStorageConfig('redis'));
+
+    expect(
+      container.getAll<Storage>('storage', { enforceBindingConstraints: true }),
+    ).to.deep.eq(expectedStorageServices);
+  });
+});

--- a/wiki/container_api.md
+++ b/wiki/container_api.md
@@ -205,7 +205,7 @@ let katana = await container.getTaggedAsync<Weapon>("Weapon", "faction", "samura
 let shuriken = await container.getTaggedAsync<Weapon>("Weapon", "faction", "ninja");
 ```
 
-## container.getAll\<T>(serviceIdentifier: interfaces.ServiceIdentifier\<T>): T[]
+## container.getAll\<T>(serviceIdentifier: interfaces.ServiceIdentifier\<T>, options?: interfaces.GetAllOptions): T[]
 
 Get all available bindings for a given identifier. All the bindings must be synchronously resolved, otherwise an error is thrown:
 
@@ -217,7 +217,21 @@ container.bind<Weapon>("Weapon").to(Shuriken);
 let weapons = container.getAll<Weapon>("Weapon");  // returns Weapon[]
 ```
 
-## container.getAllAsync\<T>(serviceIdentifier: interfaces.ServiceIdentifier\<T>): Promise\<T[]>
+Keep in mind `container.getAll` doesn't enforce binding contraints by default in the root level, enable the `enforceBindingConstraints` flag to force this binding constraint check:
+
+```ts
+let container = new Container();
+container.bind<Weapon>("Weapon").to(Katana).when(() => true);
+container.bind<Weapon>("Weapon").to(Shuriken).when(() => false);
+
+let allWeapons = container.getAll<Weapon>("Weapon");  // returns [new Katana(), new Shuriken()]
+let notAllWeapons = container.getAll<Weapon>(
+  "Weapon",
+  { enforceBindingConstraints: true },
+);  // returns [new Katana()]
+```
+
+## container.getAllAsync\<T>(serviceIdentifier: interfaces.ServiceIdentifier\<T>, options?: interfaces.GetAllOptions): Promise\<T[]>
 
 Get all available bindings for a given identifier:
 
@@ -227,6 +241,20 @@ container.bind<Weapon>("Weapon").to(Katana);
 container.bind<Weapon>("Weapon").toDynamicValue(async () => new Shuriken());
 
 let weapons = await container.getAllAsync<Weapon>("Weapon");  // returns Promise<Weapon[]>
+```
+
+Keep in mind `container.getAll` doesn't enforce binding contraints by default in the root level, enable the `enforceBindingConstraints` flag to force this binding constraint check:
+
+```ts
+let container = new Container();
+container.bind<Weapon>("Weapon").to(Katana).when(() => true);
+container.bind<Weapon>("Weapon").to(Shuriken).when(() => false);
+
+let allWeapons = await container.getAllAsync<Weapon>("Weapon");  // returns Promise.resolve([new Katana(), new Shuriken()])
+let notAllWeapons = container.getAllAsync<Weapon>(
+  "Weapon",
+  { enforceBindingConstraints: true },
+);  // returns Promise.resolve([new Katana()])
 ```
 
 ## container.getAllNamed\<T>(serviceIdentifier: interfaces.ServiceIdentifier\<T>, named: string | number | symbol): T[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Added `GetAllOptions` type.
- Updated `container.getAll` with optional `GetAllOptions` param.
- Updated `container.getAllAsync` with optional `GetAllOptions` param.

## Related Issue
#1670

## Motivation and Context
`container.getAll` behavior is fairly confusing. Users might be interested in enabling binding constraints in the root level of a plan. `GetAllOptions` is introduced to provide such a behavior without reaking the exisitng one.

## How Has This Been Tested?
- Tests have been added to cover whis scenario.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
