### PR TITLE
Extract plan metadata interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+- Updated `interfaces.NextArgs` with optional `isOptional` param.
 
 ### Fixed
 

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -143,6 +143,7 @@ namespace interfaces {
     avoidConstraints: boolean;
     contextInterceptor: (contexts: Context) => Context;
     isMultiInject: boolean;
+    isOptional?: boolean;
     targetType: TargetType;
     serviceIdentifier: interfaces.ServiceIdentifier<T>;
     key?: string | number | symbol | undefined;

--- a/src/test/planning/planner.test.ts
+++ b/src/test/planning/planner.test.ts
@@ -79,9 +79,11 @@ describe('Planner', () => {
     const actualPlan: Plan = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     ).plan;
     const actualNinjaRequest: interfaces.Request = actualPlan.rootRequest;
     const actualKatanaRequest: interfaces.Request | undefined =
@@ -233,9 +235,11 @@ describe('Planner', () => {
     const actualPlan: Plan = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     ).plan;
 
     expect(actualPlan.rootRequest.serviceIdentifier).eql(ninjaId);
@@ -285,9 +289,11 @@ describe('Planner', () => {
     const actualPlan: Plan = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     ).plan;
 
     // root request has no target
@@ -399,13 +405,9 @@ describe('Planner', () => {
     container.bind<Shuriken>(shurikenId).to(Shuriken);
 
     const throwFunction: () => void = () => {
-      plan(
-        new MetadataReader(),
-        container,
-        false,
-        TargetTypeEnum.Variable,
-        ninjaId,
-      );
+      plan(new MetadataReader(), container, TargetTypeEnum.Variable, ninjaId, {
+        isMultiInject: false,
+      });
     };
 
     expect(throwFunction).to.throw(`${ERROR_MSGS.NOT_REGISTERED} Katana`);
@@ -444,13 +446,9 @@ describe('Planner', () => {
     container.bind<Shuriken>(shurikenId).to(Shuriken);
 
     const throwFunction: () => void = () => {
-      plan(
-        new MetadataReader(),
-        container,
-        false,
-        TargetTypeEnum.Variable,
-        ninjaId,
-      );
+      plan(new MetadataReader(), container, TargetTypeEnum.Variable, ninjaId, {
+        isMultiInject: false,
+      });
     };
 
     expect(throwFunction).to.throw(`${ERROR_MSGS.AMBIGUOUS_MATCH} Katana`);
@@ -493,9 +491,11 @@ describe('Planner', () => {
     const actualPlan: Plan = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     ).plan;
 
     // root request has no target
@@ -534,13 +534,9 @@ describe('Planner', () => {
     container.bind('Weapon').to(Katana);
 
     const throwFunction: () => void = () => {
-      plan(
-        new MetadataReader(),
-        container,
-        false,
-        TargetTypeEnum.Variable,
-        'Weapon',
-      );
+      plan(new MetadataReader(), container, TargetTypeEnum.Variable, 'Weapon', {
+        isMultiInject: false,
+      });
     };
 
     expect(throwFunction).not.to.throw();
@@ -561,13 +557,9 @@ describe('Planner', () => {
     container.bind(Ninja).toSelf();
 
     const throwFunction: () => void = () => {
-      plan(
-        new MetadataReader(),
-        container,
-        false,
-        TargetTypeEnum.Variable,
-        Ninja,
-      );
+      plan(new MetadataReader(), container, TargetTypeEnum.Variable, Ninja, {
+        isMultiInject: false,
+      });
     };
 
     expect(throwFunction).to.throw(
@@ -623,9 +615,11 @@ describe('Planner', () => {
       plan(
         new MetadataReader(),
         container,
-        false,
         TargetTypeEnum.Variable,
         'Warrior',
+        {
+          isMultiInject: false,
+        },
       );
     };
 
@@ -659,13 +653,9 @@ describe('Planner', () => {
     container.bind<Katana>('Factory<Katana>').to(Katana);
 
     const throwFunction: () => void = () => {
-      plan(
-        new MetadataReader(),
-        container,
-        false,
-        TargetTypeEnum.Variable,
-        'Ninja',
-      );
+      plan(new MetadataReader(), container, TargetTypeEnum.Variable, 'Ninja', {
+        isMultiInject: false,
+      });
     };
 
     expect(throwFunction).to.throw(

--- a/src/test/planning/planner.test.ts
+++ b/src/test/planning/planner.test.ts
@@ -124,6 +124,28 @@ describe('Planner', () => {
     expect(actualShurikenRequest?.target.serviceIdentifier).eql(shurikenId);
   });
 
+  it('Should be able to create a basic plan with optional metadata', () => {
+    const ninjaId: string = 'Ninja';
+
+    const container: Container = new Container();
+
+    // Actual
+    const actualPlan: Plan = plan(
+      new MetadataReader(),
+      container,
+      TargetTypeEnum.Variable,
+      ninjaId,
+      {
+        isMultiInject: false,
+        isOptional: true,
+      },
+    ).plan;
+    const actualNinjaRequest: interfaces.Request = actualPlan.rootRequest;
+
+    expect(actualNinjaRequest.serviceIdentifier).eql(ninjaId);
+    expect(actualNinjaRequest.bindings).to.have.length(0);
+  });
+
   it('Should throw when circular dependencies found', () => {
     @injectable()
     class D {

--- a/src/test/resolution/resolver.test.ts
+++ b/src/test/resolution/resolver.test.ts
@@ -96,9 +96,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
     const ninja: Ninja = resolveTyped<Ninja>(context);
 
@@ -176,9 +178,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const katanaBinding: interfaces.Binding<unknown> | undefined =
@@ -230,9 +234,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const throwFunction: () => void = () => {
@@ -304,9 +310,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const katanaBinding: interfaces.Binding | undefined =
@@ -378,9 +386,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
     const ninja: Ninja = resolveTyped<Ninja>(context);
 
@@ -462,9 +472,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);
@@ -546,9 +558,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
     const ninja: Ninja = resolveTyped<Ninja>(context);
 
@@ -639,9 +653,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Warrior>(context);
@@ -699,9 +715,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);
@@ -753,9 +771,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);
@@ -813,9 +833,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);
@@ -868,9 +890,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);
@@ -887,9 +911,11 @@ describe('Resolve', () => {
     const context2: interfaces.Context = plan(
       new MetadataReader(),
       container2,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja2: Ninja = resolveTyped<Ninja>(context2);
@@ -943,9 +969,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = await resolveTyped<Promise<Ninja>>(context);
@@ -964,9 +992,11 @@ describe('Resolve', () => {
     const context2: interfaces.Context = plan(
       new MetadataReader(),
       container2,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja2: Ninja = await resolveTyped<Promise<Ninja>>(context2);
@@ -1011,9 +1041,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       crazyInjectableId,
+      {
+        isMultiInject: false,
+      },
     );
     const crazyInjectable: CrazyInjectable =
       await resolveTyped<Promise<CrazyInjectable>>(context);
@@ -1081,9 +1113,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);
@@ -1158,9 +1192,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);
@@ -1217,9 +1253,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);
@@ -1292,9 +1330,11 @@ describe('Resolve', () => {
     const context: interfaces.Context = plan(
       new MetadataReader(),
       container,
-      false,
       TargetTypeEnum.Variable,
       ninjaId,
+      {
+        isMultiInject: false,
+      },
     );
 
     const ninja: Ninja = resolveTyped<Ninja>(context);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added `PlanMetadata` internal interface.
- Updated `interfaces.NextArgs` with `isOptional`.

## Related Issue
#566

## Motivation and Context
This PR updates the planning algorithm in a way it can be requested optional activations in the root level of the plan.

## How Has This Been Tested?
- Test passes successfully.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have updated the changelog.
