### PR TITLE
fix: add back lazy service identifier with typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [6.1.1]
+
+### Changed
+- Added back missing `LazyServiceIdentifer` export.
+
 ## [6.1.0]
 
 ### Changed

--- a/src/inversify.ts
+++ b/src/inversify.ts
@@ -1,6 +1,10 @@
 import * as keys from './constants/metadata_keys';
 
 export { LazyServiceIdentifier } from '@inversifyjs/common';
+/**
+ * @deprecated This is a typo. Use `LazyServiceIdentifier` instead.
+ */
+export { LazyServiceIdentifier as LazyServiceIdentifer } from '@inversifyjs/common';
 // eslint-disable-next-line @typescript-eslint/typedef
 export const METADATA_KEY = keys;
 export { Container } from './container/container';


### PR DESCRIPTION
Relates to #1684 