### PR TITLE
docs: clarify emitDecoratorMetadata requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,19 +68,6 @@ You can get the latest release and the type definitions using your preferred pac
 
 `reflect-metadata` will be automatically imported by inversify.
 
-The InversifyJS type definitions are included in the inversify npm package.
-
-> :warning: **Important!** InversifyJS requires TypeScript >= 4.4 and the `experimentalDecorators`, `emitDecoratorMetadata`, compilation options in your `tsconfig.json` file.
-
-```json
-{
-  "compilerOptions": {
-    "experimentalDecorators": true,
-    "emitDecoratorMetadata": true
-  }
-}
-```
-
 InversifyJS requires a modern JavaScript engine with support for:
 
 - [Reflect metadata](https://rbuckton.github.io/reflect-metadata/)
@@ -92,6 +79,25 @@ If your environment doesn't support one of these you will need to import a shim 
 
 Check out the [Environment support and polyfills](https://github.com/inversify/InversifyJS/blob/master/wiki/environment.md)
 page in the wiki and the [Basic example](https://github.com/inversify/inversify-basic-example) to learn more.
+
+### TypeScript
+
+The InversifyJS type definitions are included in the inversify npm package.
+
+TypeScript >= 4.4 is required.
+
+Add the `experimentalDecorators` compiler option to your `tsconfig.json`.
+Also add `emitDecoratorMetadata` if you want to enable class injection without
+`@inject` as described in [Support for classes](https://github.com/inversify/InversifyJS/blob/master/wiki/classes_as_id.md).
+
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true
+  }
+}
+```
 
 ## The Basics
 Let’s take a look at the basic usage and APIs of InversifyJS with TypeScript:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

emitDecoratorMetadata is not available in some environments so it is helpful to clarify that it is not strictly required. Also I broke out a separate sub-section for TypeScript under Installation.

## Related Issue

Related: #1493

## Motivation and Context

I wanted to transition to using tsx runtime which does not support `emitDecoratorMetadata`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Updated docs / Refactor code / Added a tests case (non-breaking change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have updated the changelog.
